### PR TITLE
Update PIDLResourceFactory for net8

### DIFF
--- a/dotnet/PIDLResourceFactory/PIDLResourceFactory.csproj
+++ b/dotnet/PIDLResourceFactory/PIDLResourceFactory.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../PIDLResourceFactory.cs" Link="PIDLResourceFactory.cs" />
+  </ItemGroup>
+</Project>

--- a/dotnet/PIDLResourceFactory/README.md
+++ b/dotnet/PIDLResourceFactory/README.md
@@ -1,0 +1,6 @@
+# PIDLResourceFactory
+
+This folder contains a minimal .NET 8.0 project that builds the `PIDLResourceFactory` class.
+The source was ported from an older framework and no longer relies on `System.Web` types.
+Any previous usage of `HttpRequestMessage` has been removed so the code can compile
+without ASP.NET dependencies.


### PR DESCRIPTION
## Summary
- port `PIDLResourceFactory` to .NET 8.0
- drop `System.Web` usage and custom parse query logic
- add a minimal project file and docs

## Testing
- `dotnet build dotnet/PIDLResourceFactory/PIDLResourceFactory.csproj -c Release` *(fails: Constants not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881ccdaee888329921bdf3e1ca43a1c