### PR TITLE
Fix HttpContext usage in PidlDigitizationResourceFactory

### DIFF
--- a/dotnet/WebHostingUtility/HttpContext.cs
+++ b/dotnet/WebHostingUtility/HttpContext.cs
@@ -1,0 +1,25 @@
+using System;
+namespace System.Web
+{
+    public class HttpRequest
+    {
+        public HttpRequest(Uri url)
+        {
+            Url = url;
+        }
+
+        public Uri Url { get; set; }
+    }
+
+    public class HttpContext
+    {
+        public static HttpContext? Current { get; set; }
+
+        public HttpRequest Request { get; }
+
+        public HttpContext(HttpRequest request)
+        {
+            Request = request;
+        }
+    }
+}

--- a/dotnet/WebHostingUtility/PidlDigitizationResourceFactory.cs
+++ b/dotnet/WebHostingUtility/PidlDigitizationResourceFactory.cs
@@ -455,7 +455,7 @@ namespace Microsoft.Commerce.Payments.PidlFactory.V7
         {
             // TODO Remove dependency on HttpContext.  For example when running as part of unit tests, HttpContext will be null
             Uri currentUrl = new Uri("http://localhost"); // lgtm[cs/non-https-url] Suppressing Semmle warning // DevSkim: ignore DS137138 as this to access the locally hosted endpoint
-            if (!WebHostingUtility.IsApplicationSelfHosted())
+            if (!WebHostingUtility.IsApplicationSelfHosted() && HttpContext.Current != null)
             {
                 currentUrl = new Uri(HttpContext.Current.Request.Url.ToString().ToLower());
             }


### PR DESCRIPTION
## Summary
- stub `HttpContext` and `HttpRequest` so WebHostingUtility can compile
- guard `HttpContext.Current` usage in `PidlDigitizationResourceFactory`

## Testing
- `dotnet build dotnet/WebHostingUtility/WebHostingUtility.csproj -v minimal` *(fails: Microsoft.* libs missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881dc479f94832994b45d0563fc7652