### PR TITLE
Fix path for .NET8

### DIFF
--- a/dotnet/DisplayDescriptionFactory.cs
+++ b/dotnet/DisplayDescriptionFactory.cs
@@ -568,15 +568,13 @@ namespace Microsoft.Commerce.Payments.PidlFactory.V7
 
             if (WebHostingUtility.IsApplicationSelfHosted())
             {
-                string locationBeforeShadowCopy = typeof(Microsoft.Commerce.Payments.PidlFactory.V7.PIDLResourceFactory).Assembly.CodeBase;
-                UriBuilder uri = new UriBuilder(new Uri(locationBeforeShadowCopy));
-                string locationWithoutUriPrefixes = Uri.UnescapeDataString(uri.Path);
-                string dir = Path.GetDirectoryName(locationWithoutUriPrefixes);
-                displayDescriptionFolderPath = Path.Combine(dir, Constants.PidlConfig.DisplayDescriptionFolderRootPath);
+                string assemblyLocation = typeof(Microsoft.Commerce.Payments.PidlFactory.V7.PIDLResourceFactory).Assembly.Location;
+                string? dir = Path.GetDirectoryName(assemblyLocation);
+                displayDescriptionFolderPath = Path.Combine(dir ?? string.Empty, Constants.PidlConfig.DisplayDescriptionFolderRootPath);
             }
             else
             {
-                displayDescriptionFolderPath = System.Web.HttpContext.Current.Server.MapPath(GlobalConstants.FolderNames.WebAppData + Constants.PidlConfig.DisplayDescriptionFolderRootPath);
+                displayDescriptionFolderPath = Path.Combine(AppContext.BaseDirectory, GlobalConstants.FolderNames.WebAppData, Constants.PidlConfig.DisplayDescriptionFolderRootPath);
             }
 
             return displayDescriptionFolderPath;


### PR DESCRIPTION
## Summary
- update `GetDisplayDescriptionFolderPath` to remove obsolete `System.Web` usage

## Testing
- `dotnet build dotnet/WebHostingUtility/WebHostingUtility.csproj` *(fails: PIDLResource references missing)*

------
https://chatgpt.com/codex/tasks/task_e_688293d9fa10832991a3b437eab41230