### PR TITLE
Start migration to .NET 8

### DIFF
--- a/dotnet/PXService.Web/PXService.Web.csproj
+++ b/dotnet/PXService.Web/PXService.Web.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/dotnet/PXService.Web/Program.cs
+++ b/dotnet/PXService.Web/Program.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+app.MapGet("/probe", ([FromServices] IConfiguration config) =>
+{
+    var buildVersion = config["BuildVersion"] ?? "";
+    return new ServiceStatus { Status = "Alive", BuildVersion = buildVersion };
+});
+
+app.Run();
+
+public class ServiceStatus
+{
+    public string? Status { get; set; }
+    public string? BuildVersion { get; set; }
+}

--- a/dotnet/PXService.Web/README.md
+++ b/dotnet/PXService.Web/README.md
@@ -1,0 +1,7 @@
+# PXService.Web
+
+This folder contains the beginning of the .NET 8 migration for the legacy `PXService` web application.
+
+The project is a minimal ASP.NET Core Web API targeting **.NET 8**. It exposes a `/probe` endpoint which returns the service status and build version from configuration, matching the behavior of the original `ProbeController`.
+
+Further migration work is required to port the remaining controllers, filters, and configuration from the existing .NET Framework project.


### PR DESCRIPTION
## Summary
- scaffold a new `PXService.Web` ASP.NET Core app targeting .NET 8
- implement `/probe` endpoint returning `ServiceStatus`
- document that this is the beginning of the migration

## Testing
- ❌ `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b9405614832984ee4b97532300ad