### PR TITLE
Add NET8 compatibility for CertificateContainer

### DIFF
--- a/dotnet/InstallCertificate/CertificateContainer.cs
+++ b/dotnet/InstallCertificate/CertificateContainer.cs
@@ -202,7 +202,11 @@ namespace Microsoft.Commerce.Payments.Tools.InstallCertificates
 
             try
             {
+#if NET8_0_OR_GREATER
+                rsa = this.certificate.GetRSAPrivateKey() as RSACryptoServiceProvider;
+#else
                 rsa = this.certificate.PrivateKey as RSACryptoServiceProvider;
+#endif
                 if (rsa == null)
                 {
                     Logger.Log("Could not cast private key to RSACryptoServiceProvider");
@@ -254,7 +258,11 @@ namespace Microsoft.Commerce.Payments.Tools.InstallCertificates
 
             try
             {
+#if NET8_0_OR_GREATER
+                rsa = this.certificate.GetRSAPrivateKey() as RSACryptoServiceProvider;
+#else
                 rsa = this.certificate.PrivateKey as RSACryptoServiceProvider;
+#endif
                 if (rsa == null)
                 {
                     Logger.Log("Could not cast private key to RSACryptoServiceProvider");


### PR DESCRIPTION
## Summary
- make `CertificateContainer` compile on NET 8 by using `GetRSAPrivateKey`

## Testing
- `dotnet build dotnet/InstallCertificate/InstallCertificates.csproj` *(fails: The imported project "/msbuild/Environment.props" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883455e4fc48329ad589158e40bb52f