### PR TITLE
Fix missing CryptoKeySecurity reference

### DIFF
--- a/dotnet/InstallCertificate/InstallCertificates.csproj
+++ b/dotnet/InstallCertificate/InstallCertificates.csproj
@@ -129,6 +129,8 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Security.AccessControl" />
+    <Reference Include="System.Security.Principal.Windows" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="InstallCertificatesIntSettings.cs" />


### PR DESCRIPTION
## Summary
- add missing references for System.Security.AccessControl and System.Security.Principal.Windows

## Testing
- `apt-get update` *(fails: couldn't run all commands)*

------
https://chatgpt.com/codex/tasks/task_e_68834a0380a88329b32652405aacc63f