### PR TITLE
Fix logger interface usage

### DIFF
--- a/dotnet/TokenMiseValidator/TokenMiseValidator.cs
+++ b/dotnet/TokenMiseValidator/TokenMiseValidator.cs
@@ -171,17 +171,7 @@ namespace Microsoft.Commerce.Payments.PXCommon
         }
     }
 
-    // Stub interfaces and classes to allow compilation without the original
-    // Microsoft authentication libraries. These provide just enough structure
-    // for the sample TokenMiseValidator to build on .NET 8.
-    public interface IAuthenticationLogger
-    {
-        void LogMiseTokenValidationResult(
-            MiseTokenValidationResult result,
-            long latency,
-            Exception? exception,
-            string incomingRequestId);
-    }
+
 
     public static class Constants
     {

--- a/dotnet/TokenMiseValidator/TokenMiseValidator.csproj
+++ b/dotnet/TokenMiseValidator/TokenMiseValidator.csproj
@@ -5,5 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\logger\IAuthenticationLogger.cs" />
+  </ItemGroup>
 
 </Project>

--- a/dotnet/logger/AuthenticationLogger.cs
+++ b/dotnet/logger/AuthenticationLogger.cs
@@ -1,0 +1,27 @@
+namespace Microsoft.Commerce.Payments.PXCommon
+{
+    using System;
+    using Microsoft.Commerce.Tracing;
+
+    /// <summary>
+    /// Simple implementation of <see cref="IAuthenticationLogger"/> that writes
+    /// validation results to <see cref="SllWebLogger"/>.
+    /// </summary>
+    public class AuthenticationLogger : IAuthenticationLogger
+    {
+        public void LogMiseTokenValidationResult(
+            MiseTokenValidationResult result,
+            long latency,
+            Exception? exception,
+            string incomingRequestId)
+        {
+            string message = $"Token validation {(result.Success ? "succeeded" : "failed")} in {latency}ms";
+            if (exception != null)
+            {
+                message += $": {exception}";
+            }
+
+            SllWebLogger.TracePXServiceException(message, new EventTraceActivity(incomingRequestId));
+        }
+    }
+}

--- a/dotnet/logger/CertificateLogger.cs
+++ b/dotnet/logger/CertificateLogger.cs
@@ -1,0 +1,26 @@
+namespace Microsoft.Commerce.Payments.PXCommon
+{
+    using System;
+    using Microsoft.Commerce.Tracing;
+
+    /// <summary>
+    /// Logs certificate operations using <see cref="SllWebLogger"/>.
+    /// </summary>
+    public class CertificateLogger : IAuthenticationLogger
+    {
+        public void LogMiseTokenValidationResult(
+            MiseTokenValidationResult result,
+            long latency,
+            Exception? exception,
+            string incomingRequestId)
+        {
+            string message = $"Certificate operation {(result.Success ? "succeeded" : "failed")} in {latency}ms";
+            if (exception != null)
+            {
+                message += $": {exception}";
+            }
+
+            SllWebLogger.TracePXServiceException(message, new EventTraceActivity(incomingRequestId));
+        }
+    }
+}

--- a/dotnet/logger/IAuthenticationLogger.cs
+++ b/dotnet/logger/IAuthenticationLogger.cs
@@ -1,0 +1,13 @@
+namespace Microsoft.Commerce.Payments.PXCommon
+{
+    using System;
+
+    public interface IAuthenticationLogger
+    {
+        void LogMiseTokenValidationResult(
+            MiseTokenValidationResult result,
+            long latency,
+            Exception? exception,
+            string incomingRequestId);
+    }
+}

--- a/dotnet/logger/SllWebLogger.cs
+++ b/dotnet/logger/SllWebLogger.cs
@@ -1,0 +1,18 @@
+namespace Microsoft.Commerce.Payments.PXCommon
+{
+    using Microsoft.Commerce.Tracing;
+
+    /// <summary>
+    /// Provides minimal logging helpers used by the web8 project.
+    /// </summary>
+    public static class SllWebLogger
+    {
+        public static void TracePXServiceException(string message, EventTraceActivity traceActivityId)
+        {
+            // In the original implementation this would log to Microsoft internal
+            // tracing infrastructure. For the simplified .NET 8 port we simply
+            // write to the console so callers have a basic diagnostic trail.
+            System.Console.WriteLine($"[PXService] {traceActivityId} {message}");
+        }
+    }
+}

--- a/dotnet/logger/TokenGenerationLogger.cs
+++ b/dotnet/logger/TokenGenerationLogger.cs
@@ -1,0 +1,26 @@
+namespace Microsoft.Commerce.Payments.PXCommon
+{
+    using System;
+    using Microsoft.Commerce.Tracing;
+
+    /// <summary>
+    /// Logs token generation attempts using <see cref="SllWebLogger"/>.
+    /// </summary>
+    public class TokenGenerationLogger : IAuthenticationLogger
+    {
+        public void LogMiseTokenValidationResult(
+            MiseTokenValidationResult result,
+            long latency,
+            Exception? exception,
+            string incomingRequestId)
+        {
+            string message = $"Token generation {(result.Success ? "succeeded" : "failed")} in {latency}ms";
+            if (exception != null)
+            {
+                message += $": {exception}";
+            }
+
+            SllWebLogger.TracePXServiceException(message, new EventTraceActivity(incomingRequestId));
+        }
+    }
+}

--- a/dotnet/web8/PXService.csproj
+++ b/dotnet/web8/PXService.csproj
@@ -794,7 +794,7 @@
     <Compile Include="Model\WalletService\DirectIntegrationData.cs" />
     <Compile Include="Model\WalletService\SetupWalletProviderSessionPayload.cs" />
     <Compile Include="PartnerSettingsHelper.cs" />
-    <Compile Include="Model\Authentication\TokenGenerationLogger.cs" />
+    <Compile Include="..\logger\TokenGenerationLogger.cs" />
     <Compile Include="Model\HIPService\HIPCaptchaUserInput.cs" />
     <Compile Include="Accessors\CatalogService\CatalogServiceAccessor.cs" />
     <Compile Include="Accessors\CatalogService\ICatalogServiceAccessor.cs" />
@@ -849,8 +849,9 @@
     <Compile Include="Accessors\PurchaseService\PurchaseServiceAccessor.cs" />
     <Compile Include="CTPCommerceHelper.cs" />
     <Compile Include="CommerceHelper.cs" />
-    <Compile Include="Model\Authentication\AuthenticationLogger.cs" />
-    <Compile Include="Model\Authentication\CertificateLogger.cs" />
+    <Compile Include="..\logger\IAuthenticationLogger.cs" />
+    <Compile Include="..\logger\AuthenticationLogger.cs" />
+    <Compile Include="..\logger\CertificateLogger.cs" />
     <Compile Include="Model\Authentication\Partner.cs" />
     <Compile Include="Model\D365Service\ApiError.cs" />
     <Compile Include="Model\D365Service\BillingEvent.cs" />


### PR DESCRIPTION
## Summary
- create logger module with `IAuthenticationLogger` and console implementations
- update TokenMiseValidator and PXService projects to use the new loggers
- wire up logger files in project files

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883e599106c83299e48e4e56d525e86