### PR TITLE
Add SllWebLogger unit test

### DIFF
--- a/dotnet/logger.Tests/EventTraceActivityStub.cs
+++ b/dotnet/logger.Tests/EventTraceActivityStub.cs
@@ -1,0 +1,8 @@
+namespace Microsoft.Commerce.Tracing
+{
+    public struct EventTraceActivity
+    {
+        public static readonly EventTraceActivity Empty = new EventTraceActivity();
+        public override string ToString() => string.Empty;
+    }
+}

--- a/dotnet/logger.Tests/GlobalUsings.cs
+++ b/dotnet/logger.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/dotnet/logger.Tests/LoggerTests.csproj
+++ b/dotnet/logger.Tests/LoggerTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../logger/SllWebLogger.cs" Link="SllWebLogger.cs" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/logger.Tests/SllWebLoggerTests.cs
+++ b/dotnet/logger.Tests/SllWebLoggerTests.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.Commerce.Tracing;
+using Microsoft.Commerce.Payments.PXCommon;
+using Xunit;
+
+public class SllWebLoggerTests
+{
+    [Fact]
+    public void TracePXServiceException_WritesMessageToConsole()
+    {
+        // Arrange
+        var traceActivity = EventTraceActivity.Empty;
+        var message = "Test message";
+        var sw = new System.IO.StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(sw);
+        try
+        {
+            // Act
+            SllWebLogger.TracePXServiceException(message, traceActivity);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        // Assert
+        var output = sw.ToString().Trim();
+        Assert.Contains(message, output);
+    }
+}


### PR DESCRIPTION
## Summary
- add LoggerTests project with xUnit
- test SllWebLogger.TracePXServiceException
- add stub for EventTraceActivity to satisfy build

## Testing
- `dotnet test dotnet/logger.Tests/LoggerTests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6884023396908329af9bdce747b3ae22