### PR TITLE
Fix AuditLogger build error

### DIFF
--- a/dotnet/logger/AuditLogger.cs
+++ b/dotnet/logger/AuditLogger.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Commerce.Payments.Common.Web
                 "PUT" => OperationType.Update,
                 "PATCH" => OperationType.Update,
                 "DELETE" => OperationType.Delete,
-                _ => throw new ValidationException(ErrorCode.InvalidRequestData, "Unsupported Request method " + requestMethod)
+                _ => throw new ArgumentException("Unsupported Request method " + requestMethod, nameof(requestMethod))
             };
         }
     }


### PR DESCRIPTION
## Summary
- fix unrecognized ValidationException by using ArgumentException in AuditLogger

## Testing
- `dotnet test test.common.csproj -v:m` *(fails: Environment.props missing)*

------
https://chatgpt.com/codex/tasks/task_e_688424c901848329bc12711a31c5a6a6