### PR TITLE
refactor: use HttpRequest/HttpResponse for .NET 8

### DIFF
--- a/net88/migration/wcftest/AccountServiceAccessor.cs
+++ b/net88/migration/wcftest/AccountServiceAccessor.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
-    using HttpRequest = System.Net.Http.HttpRequestMessage;
-    using HttpResponse = System.Net.Http.HttpResponseMessage;
+    using HttpRequest = System.Net.Http.HttpRequest;
+    using HttpResponse = System.Net.Http.HttpResponse;
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Commerce.Payments.Common;

--- a/net88/migration/wcftest/HttpRequestHelper.cs
+++ b/net88/migration/wcftest/HttpRequestHelper.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
-    using HttpRequest = System.Net.Http.HttpRequestMessage;
-    using HttpResponse = System.Net.Http.HttpResponseMessage;
+    using HttpRequest = System.Net.Http.HttpRequest;
+    using HttpResponse = System.Net.Http.HttpResponse;
     using System.Web;
     using Microsoft.Commerce.Payments.Common;
     using Microsoft.Commerce.Payments.Common.Tracing;

--- a/net88/migration/wcftest/PXServiceApiVersionHandler.cs
+++ b/net88/migration/wcftest/PXServiceApiVersionHandler.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using HttpRequest = System.Net.Http.HttpRequestMessage;
-    using HttpResponse = System.Net.Http.HttpResponseMessage;
+    using HttpRequest = System.Net.Http.HttpRequest;
+    using HttpResponse = System.Net.Http.HttpResponse;
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;

--- a/net88/migration/wcftest/PXServiceAuthorizationFilterAttribute.cs
+++ b/net88/migration/wcftest/PXServiceAuthorizationFilterAttribute.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using HttpRequest = System.Net.Http.HttpRequestMessage;
-    using HttpResponse = System.Net.Http.HttpResponseMessage;
+    using HttpRequest = System.Net.Http.HttpRequest;
+    using HttpResponse = System.Net.Http.HttpResponse;
     using System.Net.Http.Headers;
     using System.Security.Cryptography.X509Certificates;
     using System.Security.Principal;

--- a/net88/migration/wcftest/PXServiceExceptionFilter.cs
+++ b/net88/migration/wcftest/PXServiceExceptionFilter.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using HttpRequest = System.Net.Http.HttpRequestMessage;
-    using HttpResponse = System.Net.Http.HttpResponseMessage;
+    using HttpRequest = System.Net.Http.HttpRequest;
+    using HttpResponse = System.Net.Http.HttpResponse;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;

--- a/net88/migration/wcftest/PXServicePIDLValidationHandler.cs
+++ b/net88/migration/wcftest/PXServicePIDLValidationHandler.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using HttpRequest = System.Net.Http.HttpRequestMessage;
-    using HttpResponse = System.Net.Http.HttpResponseMessage;
+    using HttpRequest = System.Net.Http.HttpRequest;
+    using HttpResponse = System.Net.Http.HttpResponse;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Web.Http.Routing;

--- a/net88/migration/wcftest/PurchaseServiceAccessor.cs
+++ b/net88/migration/wcftest/PurchaseServiceAccessor.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
-    using HttpRequest = System.Net.Http.HttpRequestMessage;
-    using HttpResponse = System.Net.Http.HttpResponseMessage;
+    using HttpRequest = System.Net.Http.HttpRequest;
+    using HttpResponse = System.Net.Http.HttpResponse;
     using System.Net.Http.Headers;
     using System.Text;
     using System.Threading.Tasks;


### PR DESCRIPTION
## Summary
- replace HttpRequestMessage/HttpResponseMessage aliases with System.Net.Http.HttpRequest/HttpResponse
- prepare wcftest components for .NET 8

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aa21d5ffc83299e54b33add2fe5b3