### PR TITLE
refactor: replace HttpRequest aliases with ASP.NET Core

### DIFF
--- a/net88/migration/wcftest/AccountServiceAccessor.cs
+++ b/net88/migration/wcftest/AccountServiceAccessor.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
-    using HttpRequest = System.Net.Http.HttpRequest;
-    using HttpResponse = System.Net.Http.HttpResponse;
+    using HttpRequest = Microsoft.AspNetCore.Http.HttpRequest;
+    using HttpResponse = Microsoft.AspNetCore.Http.HttpResponse;
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Commerce.Payments.Common;
@@ -356,7 +356,7 @@ namespace Microsoft.Commerce.Payments.PXService
                 traceActivityId);
         }
 
-        private static async Task HandleLegacyAddressValidationError(HttpResponse response, EventTraceActivity traceActivityId)
+        private static async Task HandleLegacyAddressValidationError(HttpResponseMessage response, EventTraceActivity traceActivityId)
         {
             string responseMessage = await response.Content.ReadAsStringAsync();
             ServiceErrorResponse error = null;
@@ -374,7 +374,7 @@ namespace Microsoft.Commerce.Payments.PXService
             throw TraceCore.TraceException(traceActivityId, new ServiceErrorResponseException() { Error = error, Response = response });
         }
 
-        private static async Task HandlePostAddressValidationError(HttpResponse response, EventTraceActivity traceActivityId)
+        private static async Task HandlePostAddressValidationError(HttpResponseMessage response, EventTraceActivity traceActivityId)
         {
             string responseMessage = await response.Content.ReadAsStringAsync();
             ServiceErrorResponse error = null;
@@ -442,7 +442,7 @@ namespace Microsoft.Commerce.Payments.PXService
         private async Task<T> SendGetRequest<T>(string requestUrl, string apiVersion, string actionName, EventTraceActivity traceActivityId)
         {
             string fullRequestUrl = string.Format("{0}{1}", this.BaseUrl, requestUrl);
-            using (HttpRequest request = new HttpRequest(HttpMethod.Get, fullRequestUrl))
+            using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, fullRequestUrl))
             {
                 request.IncrementCorrelationVector(traceActivityId);
                 request.Headers.Add(PaymentConstants.PaymentExtendedHttpHeaders.CorrelationId, traceActivityId.ActivityId.ToString());
@@ -452,7 +452,7 @@ namespace Microsoft.Commerce.Payments.PXService
                 // Add action name to the request properties so that this request's OperationName is logged properly
                 request.AddOrReplaceActionName(actionName);
 
-                using (HttpResponse response = await this.accountServiceHttpClient.SendAsync(request))
+                using (HttpResponseMessage response = await this.accountServiceHttpClient.SendAsync(request))
                 {
                     string responseMessage = await response.Content.ReadAsStringAsync();
 
@@ -486,11 +486,11 @@ namespace Microsoft.Commerce.Payments.PXService
             string actionName,
             EventTraceActivity traceActivityId,
             string etag = null,
-            Func<HttpResponse, EventTraceActivity, Task> errorHandler = null,
+            Func<HttpResponseMessage, EventTraceActivity, Task> errorHandler = null,
             bool regionIsoEnabled = false)
         {
             string fullRequestUrl = string.Format("{0}{1}", this.BaseUrl, url);
-            using (HttpRequest requestMessage = new HttpRequest(HttpMethod.Post, fullRequestUrl))
+            using (HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Post, fullRequestUrl))
             {
                 requestMessage.IncrementCorrelationVector(traceActivityId);
                 requestMessage.Headers.Add(PaymentConstants.PaymentExtendedHttpHeaders.CorrelationId, traceActivityId.ActivityId.ToString());
@@ -522,7 +522,7 @@ namespace Microsoft.Commerce.Payments.PXService
                     requestMessage.Content = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, PaymentConstants.HttpMimeTypes.JsonContentType); // lgtm[cs/sensitive-data-transmission] lgtm[cs/web/xss] The request is being made to a web service and not to a web page.
                 }
 
-                using (HttpResponse response = await this.accountServiceHttpClient.SendAsync(requestMessage))
+                using (HttpResponseMessage response = await this.accountServiceHttpClient.SendAsync(requestMessage))
                 {
                     string responseMessage = await response.Content.ReadAsStringAsync();
 
@@ -562,10 +562,10 @@ namespace Microsoft.Commerce.Payments.PXService
             EventTraceActivity traceActivityId,
             HttpMethod method,
             string etag = null,
-            Func<HttpResponse, EventTraceActivity, Task> errorHandler = null)
+            Func<HttpResponseMessage, EventTraceActivity, Task> errorHandler = null)
         {
             string fullRequestUrl = string.Format("{0}{1}", this.BaseUrl, url);
-            using (HttpRequest requestMessage = new HttpRequest(method, fullRequestUrl))
+            using (HttpRequestMessage requestMessage = new HttpRequestMessage(method, fullRequestUrl))
             {
                 requestMessage.IncrementCorrelationVector(traceActivityId);
                 requestMessage.Headers.Add(PaymentConstants.PaymentExtendedHttpHeaders.CorrelationId, traceActivityId.ActivityId.ToString());
@@ -600,7 +600,7 @@ namespace Microsoft.Commerce.Payments.PXService
                     requestMessage.Content = new StringContent(payload, Encoding.UTF8, PaymentConstants.HttpMimeTypes.JsonContentType);
                 }
 
-                using (HttpResponse response = await this.accountServiceHttpClient.SendAsync(requestMessage))
+                using (HttpResponseMessage response = await this.accountServiceHttpClient.SendAsync(requestMessage))
                 {
                     string responseMessage = await response.Content.ReadAsStringAsync();
 

--- a/net88/migration/wcftest/PXServiceApiVersionHandler.cs
+++ b/net88/migration/wcftest/PXServiceApiVersionHandler.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using HttpRequest = System.Net.Http.HttpRequest;
-    using HttpResponse = System.Net.Http.HttpResponse;
+    using HttpRequest = Microsoft.AspNetCore.Http.HttpRequest;
+    using HttpResponse = Microsoft.AspNetCore.Http.HttpResponse;
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;

--- a/net88/migration/wcftest/PXServiceAuthorizationFilterAttribute.cs
+++ b/net88/migration/wcftest/PXServiceAuthorizationFilterAttribute.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using HttpRequest = System.Net.Http.HttpRequest;
-    using HttpResponse = System.Net.Http.HttpResponse;
+    using HttpRequest = Microsoft.AspNetCore.Http.HttpRequest;
+    using HttpResponse = Microsoft.AspNetCore.Http.HttpResponse;
     using System.Net.Http.Headers;
     using System.Security.Cryptography.X509Certificates;
     using System.Security.Principal;
@@ -112,7 +112,7 @@ namespace Microsoft.Commerce.Payments.PXService
 
         private static void HandleDecline(HttpActionContext actionContext, HttpStatusCode statusCode, string errorMessage)
         {
-            actionContext.Response = new HttpResponse(statusCode)
+            actionContext.Response = new HttpResponseMessage(statusCode)
             {
                 ReasonPhrase = errorMessage
             };

--- a/net88/migration/wcftest/PXServiceExceptionFilter.cs
+++ b/net88/migration/wcftest/PXServiceExceptionFilter.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using HttpRequest = System.Net.Http.HttpRequest;
-    using HttpResponse = System.Net.Http.HttpResponse;
+    using HttpRequest = Microsoft.AspNetCore.Http.HttpRequest;
+    using HttpResponse = Microsoft.AspNetCore.Http.HttpResponse;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;

--- a/net88/migration/wcftest/PXServicePIDLValidationHandler.cs
+++ b/net88/migration/wcftest/PXServicePIDLValidationHandler.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using HttpRequest = System.Net.Http.HttpRequest;
-    using HttpResponse = System.Net.Http.HttpResponse;
+    using HttpRequest = Microsoft.AspNetCore.Http.HttpRequest;
+    using HttpResponse = Microsoft.AspNetCore.Http.HttpResponse;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Web.Http.Routing;
@@ -56,9 +56,9 @@ namespace Microsoft.Commerce.Payments.PXService
             return validationSucceeded;
         }
 
-        protected override async Task<HttpResponse> SendAsync(HttpRequest request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            HttpResponse response = await base.SendAsync(request, cancellationToken);
+            HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
 
             try
             {

--- a/net88/migration/wcftest/PurchaseServiceAccessor.cs
+++ b/net88/migration/wcftest/PurchaseServiceAccessor.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
-    using HttpRequest = System.Net.Http.HttpRequest;
-    using HttpResponse = System.Net.Http.HttpResponse;
+    using HttpRequest = Microsoft.AspNetCore.Http.HttpRequest;
+    using HttpResponse = Microsoft.AspNetCore.Http.HttpResponse;
     using System.Net.Http.Headers;
     using System.Text;
     using System.Threading.Tasks;
@@ -258,7 +258,7 @@ namespace Microsoft.Commerce.Payments.PXService
             string apiVersion = null)
         {
             string fullRequestUrl = string.IsNullOrWhiteSpace(baseUrl) ? actionPath : string.Format("{0}/{1}", this.BaseUrl, actionPath);
-            using (HttpRequest requestMessage = new HttpRequest(method, fullRequestUrl))
+            using (HttpRequestMessage requestMessage = new HttpRequestMessage(method, fullRequestUrl))
             {
                 requestMessage.IncrementCorrelationVector(traceActivityId);
                 requestMessage.Headers.Add(PaymentConstants.PaymentExtendedHttpHeaders.CorrelationId, traceActivityId.ActivityId.ToString());
@@ -283,7 +283,7 @@ namespace Microsoft.Commerce.Payments.PXService
                 }
 
                 // CodeQL [SM03781] Safe to use. We have implemented the fix in line 144-152.
-                using (HttpResponse response = await this.purchaseServiceHttpClient.SendAsync(requestMessage))
+                using (HttpResponseMessage response = await this.purchaseServiceHttpClient.SendAsync(requestMessage))
                 {
                     string responseMessage = await response.Content.ReadAsStringAsync();
 


### PR DESCRIPTION
## Summary
- swap HttpRequest/HttpResponse aliases to Microsoft.AspNetCore.Http
- update helpers and accessors to use HttpRequestMessage/HttpResponseMessage

## Testing
- `dotnet build net88/migration/PXDependencyEmulators.csproj` *(fails: IAzureExPAccessor could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_688aa973f43483298d84e85eda404d0e