### PR TITLE
Fix error handler delegate parameter

### DIFF
--- a/net88/migration/wcftest/AccountServiceAccessor.cs
+++ b/net88/migration/wcftest/AccountServiceAccessor.cs
@@ -87,7 +87,8 @@ namespace Microsoft.Commerce.Payments.PXService
                     address,
                     "PostAddress",
                     traceActivityId,
-                    errorHandler: HandlePostAddressValidationError);
+                    null,
+                    HandlePostAddressValidationError);
         }
 
         /// <summary>
@@ -315,7 +316,8 @@ namespace Microsoft.Commerce.Payments.PXService
                     address,
                     "LegacyValidation",
                     traceActivityId,
-                    errorHandler: HandleLegacyAddressValidationError);
+                    null,
+                    HandleLegacyAddressValidationError);
         }
 
         public async Task<T> ModernValidateAddress<T>(object address, EventTraceActivity traceActivityId, bool regionIsoEnabled = false)


### PR DESCRIPTION
## Summary
- Fix `SendPostRequest` calls to pass explicit `etag` argument before error handlers

## Testing
- `dotnet build` *(fails: The type or namespace name 'ITransactionDataServiceAccessor' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_688be8cac9208329a04c43c9ad8f4c5e