### PR TITLE
refactor: modernize SllWebLogger for .NET 8

### DIFF
--- a/net88/migration/wcftest/SllWebLogger.cs
+++ b/net88/migration/wcftest/SllWebLogger.cs
@@ -54,17 +54,12 @@ namespace Microsoft.Commerce.Payments.Common.Web
             string message)
         {
             // Not all the APIs have version.
-            string apiExternalVersion = string.Empty;
-            if (request.Properties.ContainsKey(PaymentConstants.Web.Properties.Version))
-            {
-                apiExternalVersion = request.GetApiVersion().ExternalVersion;
-            }
+            var apiVersion = request.GetApiVersion();
+            string apiExternalVersion = apiVersion?.ExternalVersion ?? string.Empty;
 
-            object callerObject;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.CallerName, out callerObject);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.CallerName), out var callerObject);
 
-            object callerThumbprintObject;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.CallerThumbprint, out callerThumbprintObject);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.CallerThumbprint), out var callerThumbprintObject);
 
             Ms.Qos.ServiceRequestStatus operationStatus = Ms.Qos.ServiceRequestStatus.Undefined;
 
@@ -133,14 +128,12 @@ namespace Microsoft.Commerce.Payments.Common.Web
                 SllLogger.EnvironmentLogOption,
                 (envelope) =>
                 {
-                    object flightingExperimentId;
-                    if (request.Properties.TryGetValue(PaymentConstants.Web.Properties.FlightingExperimentId, out flightingExperimentId))
+                    if (request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.FlightingExperimentId), out var flightingExperimentId))
                     {
                         envelope.SetApp(new Telemetry.Extensions.app { expId = flightingExperimentId.ToString() });
                     }
 
-                    object scenarioId;
-                    if (request.Properties.TryGetValue(PaymentConstants.Web.Properties.ScenarioId, out scenarioId) && envelope.tags != null)
+                    if (envelope.tags != null && request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.ScenarioId), out var scenarioId))
                     {
                         envelope.tags["scenarioId"] = scenarioId.ToString();
                     }
@@ -200,14 +193,10 @@ namespace Microsoft.Commerce.Payments.Common.Web
             string avsSuggest = null)
         {
             // Not all the APIs have version.
-            string apiExternalVersion = string.Empty;
-            if (request.Properties.ContainsKey(PaymentConstants.Web.Properties.Version))
-            {
-                apiExternalVersion = request.GetApiVersion().ExternalVersion;
-            }
+            var apiVersion = request.GetApiVersion();
+            string apiExternalVersion = apiVersion?.ExternalVersion ?? string.Empty;
 
-            object callerObject;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.CallerName, out callerObject);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.CallerName), out var callerObject);
 
             ServiceRequestStatus operationStatus = ServiceRequestStatus.Undefined;
 
@@ -331,8 +320,7 @@ namespace Microsoft.Commerce.Payments.Common.Web
             string servicePointData = null)
         {
             // Not all the APIs have version.
-            object apiVersion = null;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.Version, out apiVersion);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.Version), out var apiVersion);
 
             Ms.Qos.ServiceRequestStatus operationStatus = Ms.Qos.ServiceRequestStatus.Undefined;
 


### PR DESCRIPTION
## Summary
- replace obsolete `HttpRequestMessage.Properties` with `Options`
- use `HttpRequestOptionsKey` for caller and scenario metadata

## Testing
- `dotnet build net88/migration/PXDependencyEmulators.csproj` *(fails: type or namespace name 'IAzureExPAccessor' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_688c5f2911f88329b1c2acde41072ebc