### PR TITLE
Add .NET 8 project file for PXNet

### DIFF
--- a/net8/migration/wcftest/pxnet/pxnet.csproj
+++ b/net8/migration/wcftest/pxnet/pxnet.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters" Version="2.0.0" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="UAParser" Version="3.1.47" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add net8.0 project file for PXNet sample including SystemWebAdapters, YARP, Newtonsoft.Json and UAParser packages

## Testing
- `dotnet build` *(fails: type or namespace name 'ChallengeManagementService' does not exist ...)*

------
https://chatgpt.com/codex/tasks/task_e_688cb07c62688329ad8e5fa32f2edf88