### PR TITLE
chore: migrate controllers to aspnetcore

### DIFF
--- a/net8/migration/PXService.NetStandard/Controllers/AddressDescriptionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/AddressDescriptionsController.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
@@ -42,7 +42,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
         public async Task<List<PIDLResource>> GetById(
-            [FromUri]string accountId,
+            string accountId,
             string country,
             string type,
             string language = null,
@@ -373,7 +373,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
         public async Task<List<PIDLResource>> GetAddressGroupsById(
-            [FromUri]string accountId,
+            string accountId,
             string country,
             string operation = Constants.Operations.SelectInstance,
             string language = null,

--- a/net8/migration/PXService.NetStandard/Controllers/AddressesController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/AddressesController.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common.Tracing;
     using Common.Web;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;

--- a/net8/migration/PXService.NetStandard/Controllers/AgenticTokenDesctipionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/AgenticTokenDesctipionsController.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;
     using Microsoft.Commerce.Payments.PidlFactory.V7;
     using Microsoft.Commerce.Payments.PidlModel.V7;   
@@ -28,7 +28,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]        
         [HttpGet]
-        public List<PIDLResource> Get([FromUri] string accountId, string country, string type, string operation, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string piid = null)
+        public List<PIDLResource> Get(string accountId, string country, string type, string operation, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string piid = null)
         {
             // Use Partner Settings if enabled for the partner
             PaymentExperienceSetting setting = this.GetPaymentExperienceSetting(operation);

--- a/net8/migration/PXService.NetStandard/Controllers/BillingGroupDescriptionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/BillingGroupDescriptionsController.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;
@@ -31,7 +31,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
-        public List<PIDLResource> GetBillingGroupsDescription([FromUri]string accountId, string country, string operation = Constants.Operations.SelectInstance, string type = null, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string scenario = null)
+        public List<PIDLResource> GetBillingGroupsDescription(string accountId, string country, string operation = Constants.Operations.SelectInstance, string type = null, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string scenario = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 

--- a/net8/migration/PXService.NetStandard/Controllers/ChallengeDescriptionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/ChallengeDescriptionsController.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
@@ -51,7 +51,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
         public async Task<List<PIDLResource>> GetById(
-            [FromUri] string accountId,
+            string accountId,
             string type,
             string language = null,
             string partner = Constants.ServiceDefaults.DefaultPartnerName)
@@ -106,8 +106,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
         public async Task<List<PIDLResource>> GetByTypePiidAndSessionId(
-            [FromUri] string accountId,
-            [FromUri] string piid,
+            string accountId,
+            string piid,
             string type,
             string sessionId,
             string language = null,
@@ -170,8 +170,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
         public async Task<List<PIDLResource>> GetByTypeAndPiid(
-            [FromUri] string accountId,
-            [FromUri] string piid,
+            string accountId,
+            string piid,
             string type,
             string language = null,
             string partner = Constants.ServiceDefaults.DefaultPartnerName)
@@ -227,9 +227,9 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Returns challenge PIDL for the given type and specfic to the given piid</returns>
         [HttpGet]
         public async Task<HttpResponseMessage> GetPaymentChallenge(
-            [FromUri] string accountId,
-            [FromUri] string paymentSessionOrData,
-            [FromUri] string timezoneOffset = null)
+            string accountId,
+            string paymentSessionOrData,
+            string timezoneOffset = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             List<PIDLResource> resources = new List<PIDLResource>();
@@ -559,7 +559,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Returns a PIDL representing the next action that needs to be taken</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
-        public async Task<List<PIDLResource>> GetByPiidAndSessionId([FromUri] string accountId, [FromUri] string piid, string sessionId, string partner = null, string language = null, string orderId = null)
+        public async Task<List<PIDLResource>> GetByPiidAndSessionId(string accountId, string piid, string sessionId, string partner = null, string language = null, string orderId = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null, null);
@@ -660,11 +660,11 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
         public async Task<List<PIDLResource>> GetByAccountIdAndPiid(
-            [FromUri] string accountId,
-            [FromUri] string piid,
-            [FromUri] string language = null,
-            [FromUri] bool revertChallengeOption = false,
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName)
+            string accountId,
+            string piid,
+            string language = null,
+            bool revertChallengeOption = false,
+            string partner = Constants.ServiceDefaults.DefaultPartnerName)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null, null);

--- a/net8/migration/PXService.NetStandard/Controllers/CheckoutDescriptionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/CheckoutDescriptionsController.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;

--- a/net8/migration/PXService.NetStandard/Controllers/CheckoutRequestsExController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/CheckoutRequestsExController.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common.Web;
     using Microsoft.Commerce.Payments.Common;
     using Microsoft.Commerce.Payments.Common.Tracing;
@@ -49,10 +49,10 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         [HttpPost]
         public async Task<HttpResponseMessage> AttachAddress(
             [FromBody] PIDLData address,
-            [FromUri] string checkoutRequestId,
-            [FromUri] string type = null,
-            [FromUri] string partner = V7.Constants.ServiceDefaults.DefaultPartnerName,
-            [FromUri] string scenario = null)
+            string checkoutRequestId,
+            string type = null,
+            string partner = V7.Constants.ServiceDefaults.DefaultPartnerName,
+            string scenario = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -104,8 +104,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         [HttpPost]
         public async Task<HttpResponseMessage> AttachProfile(
             [FromBody] PIDLData profile,
-            [FromUri] string checkoutRequestId,
-            [FromUri] string partner = V7.Constants.ServiceDefaults.DefaultPartnerName)
+            string checkoutRequestId,
+            string partner = V7.Constants.ServiceDefaults.DefaultPartnerName)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -146,8 +146,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         [HttpPost]
         public async Task<HttpResponseMessage> Confirm(
             [FromBody] PIDLData confirmPayload,
-            [FromUri] string checkoutRequestId,
-            [FromUri] string partner = V7.Constants.TemplateName.DefaultTemplate)
+            string checkoutRequestId,
+            string partner = V7.Constants.TemplateName.DefaultTemplate)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             CheckoutRequestClientActions checkoutRequest = new CheckoutRequestClientActions();
@@ -289,8 +289,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         [HttpPost]
         public async Task<HttpResponseMessage> AttachPaymentInstrument(
             [FromBody] PIDLData paymentInstrument,
-            [FromUri] string checkoutRequestId,
-            [FromUri] string partner = V7.Constants.ServiceDefaults.DefaultPartnerName)
+            string checkoutRequestId,
+            string partner = V7.Constants.ServiceDefaults.DefaultPartnerName)
         {
             //// This API is not in use and will be removed in future
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.NetStandard/Controllers/CheckoutsExController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/CheckoutsExController.cs
@@ -7,8 +7,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.Checkouts
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Threading.Tasks;
-    using System.Web;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
@@ -41,9 +40,9 @@ namespace Microsoft.Commerce.Payments.PXService.V7.Checkouts
         /// <returns>Returns the HttpResponse to iFrame that posts message to parent window to redirect the page</returns>
         [HttpGet]
         public HttpResponseMessage Completed(
-            [FromUri] string redirectUrl,
-            [FromUri] string checkoutId,
-            [FromUri] string providerId)
+            string redirectUrl,
+            string checkoutId,
+            string providerId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -94,12 +93,12 @@ namespace Microsoft.Commerce.Payments.PXService.V7.Checkouts
         /// <returns>Returns the pidl redirect</returns>
         [HttpPost]
         public async Task<HttpResponseMessage> Charge(
-            [FromUri] string paymentProviderId,
-            [FromUri] string checkoutId,
-            [FromUri] string partner,
-            [FromUri] string redirectUrl,
+            string paymentProviderId,
+            string checkoutId,
+            string partner,
+            string redirectUrl,
             [FromBody] CheckoutChargePayload checkoutChargePayload,
-            [FromUri] string language = null)
+            string language = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -215,8 +214,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7.Checkouts
         /// <returns>Returns the status pidl</returns>
         [HttpGet]
         public async Task<HttpResponseMessage> Status(
-            [FromUri] string paymentProviderId,
-            [FromUri] string checkoutId)
+            string paymentProviderId,
+            string checkoutId)
         {            
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 

--- a/net8/migration/PXService.NetStandard/Controllers/DescriptionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/DescriptionsController.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;

--- a/net8/migration/PXService.NetStandard/Controllers/ExpressCheckoutController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/ExpressCheckoutController.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common.Web;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.PidlFactory.V7;
@@ -29,9 +29,9 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>ExpressCheckoutResult object</returns>
         [HttpPost]
         public async Task<ExpressCheckoutResult> Confirm(
-            [FromUri] string accountId,
+            string accountId,
             [FromBody] PIDLData confirmPayload,
-            [FromUri] string partner = V7.Constants.ServiceDefaults.DefaultPartnerName)
+            string partner = V7.Constants.ServiceDefaults.DefaultPartnerName)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 

--- a/net8/migration/PXService.NetStandard/Controllers/HttpRequestExtensions.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/HttpRequestExtensions.cs
@@ -1,0 +1,37 @@
+namespace Microsoft.Commerce.Payments.PXService.V7
+{
+    using System.Net;
+    using System.Net.Http;
+    using System.Text;
+    using Microsoft.AspNetCore.Http;
+    using Newtonsoft.Json;
+
+    internal static class HttpRequestExtensions
+    {
+        public static HttpResponseMessage CreateResponse(this HttpRequest request, HttpStatusCode statusCode)
+        {
+            return new HttpResponseMessage(statusCode);
+        }
+
+        public static HttpResponseMessage CreateResponse<T>(this HttpRequest request, T value)
+        {
+            return request.CreateResponse(HttpStatusCode.OK, value);
+        }
+
+        public static HttpResponseMessage CreateResponse(this HttpRequest request, HttpStatusCode statusCode, object value, string mediaType = "application/json")
+        {
+            var response = new HttpResponseMessage(statusCode);
+            if (value != null)
+            {
+                var json = JsonConvert.SerializeObject(value);
+                response.Content = new StringContent(json, Encoding.UTF8, mediaType);
+            }
+            return response;
+        }
+
+        public static HttpResponseMessage CreateErrorResponse(this HttpRequest request, HttpStatusCode statusCode, object error)
+        {
+            return request.CreateResponse(statusCode, error);
+        }
+    }
+}

--- a/net8/migration/PXService.NetStandard/Controllers/InitializationController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/InitializationController.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common.Web;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;

--- a/net8/migration/PXService.NetStandard/Controllers/MSRewardsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/MSRewardsController.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PidlFactory.V7;
@@ -34,10 +34,10 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [HttpPost]
         public async Task<PIDLResource> PostRedeemRequest(
             [FromBody] MSRewardsRedeemRequest redeemData,
-            [FromUri] string accountId,
-            [FromUri] string country = null,
-            [FromUri] string language = null,
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName)
+            string accountId,
+            string country = null,
+            string language = null,
+            string partner = Constants.ServiceDefaults.DefaultPartnerName)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, null, null, null);

--- a/net8/migration/PXService.NetStandard/Controllers/PaymentInstrumentsExController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/PaymentInstrumentsExController.cs
@@ -11,8 +11,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
-    using System.Web;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Transaction;
@@ -66,12 +65,12 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Html post message</returns>
         [HttpGet]
         public HttpResponseMessage AnonymousResumePendingOperation(
-            [FromUri] string piid,
-            [FromUri] bool isSuccessful = false,
-            [FromUri] string language = "en",
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName,
-            [FromUri] string sessionQueryUrl = null,
-            [FromUri] string country = null)
+            string piid,
+            bool isSuccessful = false,
+            string language = "en",
+            string partner = Constants.ServiceDefaults.DefaultPartnerName,
+            string sessionQueryUrl = null,
+            string country = null)
         {
             this.Request.AddPartnerProperty(partner?.ToLower());
             ClientAction nextAction = null;
@@ -124,15 +123,15 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [HttpPost]
         public async Task<HttpResponseMessage> CreateModernPI(
             [FromBody] PIDLData pi,
-            [FromUri] string sessionId = null,
-            [FromUri] string language = "en-us",
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName,
-            [FromUri] string classicProduct = null,
-            [FromUri] string billableAccountId = null,
-            [FromUri] bool completePrerequisites = false,
-            [FromUri] string country = null,
-            [FromUri] string scenario = null,
-            [FromUri] string orderId = null)
+            string sessionId = null,
+            string language = "en-us",
+            string partner = Constants.ServiceDefaults.DefaultPartnerName,
+            string classicProduct = null,
+            string billableAccountId = null,
+            bool completePrerequisites = false,
+            string country = null,
+            string scenario = null,
+            string orderId = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -183,10 +182,10 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of payment instrument or IPidlPayload object</returns>
         [HttpGet]
         public async Task<HttpResponseMessage> ListModernPIs(
-            [FromUri] string accountId,
-            [FromUri] string[] status = null,
-            [FromUri] ulong deviceId = 0,
-            [FromUri] bool includePidl = false,
+            string accountId,
+            string[] status = null,
+            ulong deviceId = 0,
+            bool includePidl = false,
             string language = "en",
             string partner = Constants.ServiceDefaults.DefaultPartnerName,
             string country = null,
@@ -323,16 +322,16 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A payment instrument object</returns>
         [HttpGet]
         public async Task<PaymentInstrument> GetModernPI(
-            [FromUri] string accountId,
-            [FromUri] string piid,
-            [FromUri] string language = "en",
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName,
-            [FromUri] bool completePrerequisites = false,
-            [FromUri] string country = null,
-            [FromUri] string scenario = null,
-            [FromUri] string sessionQueryUrl = null,
-            [FromUri] string classicProduct = null,
-            [FromUri] string sessionId = null)
+            string accountId,
+            string piid,
+            string language = "en",
+            string partner = Constants.ServiceDefaults.DefaultPartnerName,
+            bool completePrerequisites = false,
+            string country = null,
+            string scenario = null,
+            string sessionQueryUrl = null,
+            string classicProduct = null,
+            string sessionId = null)
         {
             PaymentExperienceSetting setting = this.GetPaymentExperienceSetting(Constants.Operations.Add);
             if (PXCommon.Constants.PartnerGroups.IsVenmoEnabledPartner(partner) || TemplateHelper.IsTemplateBasedPIDLIncludingDefaultTemplate(TemplateHelper.GetSettingTemplate(partner, setting, Constants.DescriptionTypes.PaymentMethodDescription, $"{Constants.PaymentMethodFamily.ewallet}.{Constants.PaymentMethodType.Venmo}")))
@@ -533,16 +532,16 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A payment instrument object</returns>
         [HttpPost]
         public async Task<HttpResponseMessage> PostModernPI(
-            [FromUri] string accountId,
+            string accountId,
             [FromBody] PIDLData pi,
-            [FromUri] string language = "en",
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName,
-            [FromUri] string classicProduct = null,
-            [FromUri] string billableAccountId = null,
-            [FromUri] bool completePrerequisites = false,
-            [FromUri] string country = null,
-            [FromUri] string scenario = null,
-            [FromUri] string orderId = null)
+            string language = "en",
+            string partner = Constants.ServiceDefaults.DefaultPartnerName,
+            string classicProduct = null,
+            string billableAccountId = null,
+            bool completePrerequisites = false,
+            string country = null,
+            string scenario = null,
+            string orderId = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddPartnerProperty(partner?.ToLower());
@@ -577,12 +576,12 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A payment instrument object</returns>
         [HttpPost]
         public async Task<HttpResponseMessage> UpdateModernPI(
-            [FromUri] string accountId,
-            [FromUri] string piid,
+            string accountId,
+            string piid,
             [FromBody] PIDLData pi,
-            [FromUri] string language = "en",
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName,
-            [FromUri] string billableAccountId = null)
+            string language = "en",
+            string partner = Constants.ServiceDefaults.DefaultPartnerName,
+            string billableAccountId = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddPartnerProperty(partner?.ToLower());
@@ -744,15 +743,15 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A payment instrument object</returns>
         [HttpPost]
         public async Task<HttpResponseMessage> ReplaceModernPI(
-            [FromUri] string accountId,
-            [FromUri] string piid,
+            string accountId,
+            string piid,
             [FromBody] PIDLData pi,
-            [FromUri] string language = "en",
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName,
-            [FromUri] string classicProduct = null,
-            [FromUri] bool completePrerequisites = false,
-            [FromUri] string country = null,
-            [FromUri] string scenario = null)
+            string language = "en",
+            string partner = Constants.ServiceDefaults.DefaultPartnerName,
+            string classicProduct = null,
+            bool completePrerequisites = false,
+            string country = null,
+            string scenario = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddPartnerProperty(partner?.ToLower());
@@ -871,12 +870,12 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A PIDLResource object</returns>
         [HttpPost]
         public async Task<PIDLResource> RedeemModernPI(
-            [FromUri] string accountId,
-            [FromUri] string piid,
+            string accountId,
+            string piid,
             [FromBody] PIDLData pi,
-            [FromUri] string country = "us",
-            [FromUri] string language = "en",
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName)
+            string country = "us",
+            string language = "en",
+            string partner = Constants.ServiceDefaults.DefaultPartnerName)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null);
@@ -927,16 +926,16 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A payment instrument object</returns>
         [HttpGet]
         public async Task<object> RedeemModernPI(
-            [FromUri] string accountId,
-            [FromUri] string piid,
+            string accountId,
+            string piid,
             [FromBody] PIDLData pi,
-            [FromUri] string amount,
-            [FromUri] string referenceId,
-            [FromUri] string country = "us",
-            [FromUri] string language = "en",
-            [FromUri] string currency = "USD",
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName,
-            [FromUri] string greenId = "")
+            string amount,
+            string referenceId,
+            string country = "us",
+            string language = "en",
+            string currency = "USD",
+            string partner = Constants.ServiceDefaults.DefaultPartnerName,
+            string greenId = "")
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null);
@@ -977,11 +976,11 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A payment instrument object</returns>
         [HttpPost]
         public async Task<HttpResponseMessage> RemoveModernPI(
-            [FromUri] string accountId,
-            [FromUri] string piid,
+            string accountId,
+            string piid,
             [FromBody] object removeReason,
-            [FromUri] string language = "en",
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName)
+            string language = "en",
+            string partner = Constants.ServiceDefaults.DefaultPartnerName)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null);
@@ -1091,15 +1090,15 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A payment instrument object</returns>
         [HttpPost]
         public async Task<HttpResponseMessage> ResumePendingOperation(
-            [FromUri] string accountId,
-            [FromUri] string piid,
+            string accountId,
+            string piid,
             [FromBody] PIDLData pendingOpRequestData,
-            [FromUri] string language = "en",
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName,
-            [FromUri] string classicProduct = null,
-            [FromUri] string billableAccountId = null,
-            [FromUri] bool completePrerequisites = false,
-            [FromUri] string country = null)
+            string language = "en",
+            string partner = Constants.ServiceDefaults.DefaultPartnerName,
+            string classicProduct = null,
+            string billableAccountId = null,
+            bool completePrerequisites = false,
+            string country = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null);
@@ -1334,7 +1333,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A card profeil object</response>
         /// <returns>A payment instrument object</returns>
         [HttpGet]
-        public async Task<object> GetCardProfile([FromUri] string accountId, [FromUri] string piid, [FromUri] ulong deviceId)
+        public async Task<object> GetCardProfile(string accountId, string piid, ulong deviceId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null);
@@ -1354,7 +1353,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A card profeil object</response>
         /// <returns>A payment instrument object</returns>
         [HttpGet]
-        public async Task<object> GetSeCardPersos([FromUri] string accountId, [FromUri] string piid, [FromUri] ulong deviceId)
+        public async Task<object> GetSeCardPersos(string accountId, string piid, ulong deviceId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null);
@@ -1375,7 +1374,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A object</returns>
         [HttpPost]
-        public async Task<object> PostReplenishTransactionCredentials([FromUri] string accountId, [FromUri] string piid, [FromUri] ulong deviceId, [FromBody] object requestData)
+        public async Task<object> PostReplenishTransactionCredentials(string accountId, string piid, ulong deviceId, [FromBody] object requestData)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null);
@@ -1396,7 +1395,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A object</returns>
         [HttpPost]
-        public async Task<object> AcquireLUKs([FromUri] string accountId, [FromUri] string piid, [FromUri] ulong deviceId, [FromBody] object requestData)
+        public async Task<object> AcquireLUKs(string accountId, string piid, ulong deviceId, [FromBody] object requestData)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null);
@@ -1416,7 +1415,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A object</returns>
         [HttpPost]
-        public async Task<object> ConfirmLUKs([FromUri] string accountId, [FromUri] ulong deviceId, [FromUri] string piid)
+        public async Task<object> ConfirmLUKs(string accountId, ulong deviceId, string piid)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null);
@@ -1437,7 +1436,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A object</returns>
         [HttpPost]
-        public async Task<object> ValidateCvv([FromUri] string accountId, [FromUri] string piid, [FromUri] string language, [FromBody] object requestData)
+        public async Task<object> ValidateCvv(string accountId, string piid, string language, [FromBody] object requestData)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid, null, null);
@@ -1498,12 +1497,12 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Message from IssuerService API</returns>
         [HttpPost]
         public async Task<HttpResponseMessage> Apply(
-            [FromUri] string partner,
-            [FromUri] string operation,
-            [FromUri] string country,
-            [FromUri] string language,
+            string partner,
+            string operation,
+            string country,
+            string language,
             [FromBody] InitializeRequest initializeData,
-            [FromUri] string sessionId = null)
+            string sessionId = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddPartnerProperty(partner?.ToLower());
@@ -1586,8 +1585,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [HttpGet]
         [ActionName("GetChallengeContext")]
         public async Task<HttpResponseMessage> GetChallengeContext(
-            [FromUri] string accountId,
-            [FromUri] string piid)
+            string accountId,
+            string piid)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             this.Request.AddTracingProperties(accountId, piid);
@@ -3067,7 +3066,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
             if (IsCreditCard(paymentMethodFamily, paymentMethodType) && this.ExposedFlightFeatures.Contains(Flighting.Features.PXRateLimitPerAccount))
             {
                 var serviceErrorResp = GenerateValidationFailedServiceErrorResponse(language);
-                this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = $"{GlobalConstants.AbnormalDetection.LogMsgWhenCaughtByPX} " +
+                this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = $"{GlobalConstants.AbnormalDetection.LogMsgWhenCaughtByPX} " +
                     $"by flight {Flighting.Features.PXRateLimitPerAccount} limited by accountId {accountId}, family {paymentMethodFamily}, type {paymentMethodType}.";
                 return this.Request.CreateResponse(HttpStatusCode.BadRequest, serviceErrorResp, GlobalConstants.HeaderValues.JsonContent);
             }
@@ -3230,7 +3229,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
 
                 adMessage.Append("Calling IsCardTesting. ");
                 adMessage.Append(string.Join(", ", adData.ToList())).Append(". ");
-                this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
+                this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
 
                 isAnomaly = this.IsMaliciousAccountId(accountId, traceActivityId, adMessage) || this.IsMaliciousClientIP(ipAddress, traceActivityId, adMessage);
 
@@ -3239,14 +3238,14 @@ namespace Microsoft.Commerce.Payments.PXService.V7
                 if (exceedingDimensions == null)
                 {
                     adMessage.Append("Returned null. ");
-                    this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
+                    this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
                 }
                 else
                 {
                     adMessage.Append("Returned dimensions: ");
                     adMessage.Append(string.Join(", ", exceedingDimensions)).Append(". ");
                     adMessage.Append($"{GlobalConstants.AbnormalDetection.LogMsgWhenCaughtByPX}");
-                    this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
+                    this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
 
                     AnomalyDetection.AddData(adData, true);
                     isAnomaly = true;
@@ -3268,18 +3267,18 @@ namespace Microsoft.Commerce.Payments.PXService.V7
                 if (string.Equals(ObfuscationHelper.GetHashValue(accountId, ObfuscationHelper.JarvisAccountIdHashSalt), jarvisAccountIdHmac, StringComparison.OrdinalIgnoreCase))
                 {
                     adMessage.Append("JarvisAccountIdHmac matched. ");
-                    this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
+                    this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
                 }
                 else
                 {
                     adMessage.Append("JarvisAccountIdHmac did not match. ");
-                    this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
+                    this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
 
                     // Short circuit the call if JarvisAccountIdHmac is not as expected
                     var ser = GenerateValidationFailedServiceErrorResponse(language);
                     adMessage.Append($"{GlobalConstants.AbnormalDetection.LogMsgWhenCaughtByPX}");
                     adMessage.Append("Calling AddData for bad request.");
-                    this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
+                    this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
                     AnomalyDetection.AddData(adData, true);
                     return this.Request.CreateResponse(HttpStatusCode.BadRequest, ser, "application/json");
                 }
@@ -3362,7 +3361,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
                     if ((int)ex.Response.StatusCode >= 400 && (int)ex.Response.StatusCode <= 499)
                     {
                         adMessage.Append("Calling AddData for bad request.");
-                        this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
+                        this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
 
                         AnomalyDetection.AddData(adData, true);
                     }
@@ -3570,13 +3569,13 @@ namespace Microsoft.Commerce.Payments.PXService.V7
             }
 
             // Adding anomaly detection message on the request
-            this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
+            this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
 
             if (IsCreditCard(paymentMethodFamily, paymentMethodType)
                 && !Constants.PXRateLimitAddCCSkipAccounts.Contains(accountId, StringComparer.OrdinalIgnoreCase))
             {
                 adMessage.Append("Calling AddData for good request.");
-                this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
+                this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
 
                 AnomalyDetection.AddData(adData, false);
             }
@@ -3756,7 +3755,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
             {
                 adMessage.Append("Blocked based on anomaly detection result on accountId.");
                 adMessage.Append($"{GlobalConstants.AbnormalDetection.LogMsgWhenCaughtByPX}");
-                this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
+                this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
                 //// Task 41895852: Blocking is put behind another flight to remove the need for another deployment to turn on blocking based on malicious account ID
                 return this.ExposedFlightFeatures.Contains(Flighting.Features.PXEnableMaliciousAccountIdRejectionEffect);
             }
@@ -3771,7 +3770,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
             {
                 adMessage.Append("Blocked based on anomaly detection result on clientIP.");
                 adMessage.Append($"{GlobalConstants.AbnormalDetection.LogMsgWhenCaughtByPX}");
-                this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
+                this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = adMessage.ToString();
                 //// Task 41895852: Blocking is put behind another flight to remove the need for another deployment to turn on blocking based on malicious client IP
                 return this.ExposedFlightFeatures.Contains(Flighting.Features.PXEnableMaliciousClientIPRejectionEffect);
             }
@@ -3947,7 +3946,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
             else
             {
                 var serviceErrorResp = GenerateValidationFailedServiceErrorResponse(language);
-                this.Request.Properties[PaymentConstants.Web.InstrumentManagementProperties.Message] = $"{GlobalConstants.AbnormalDetection.LogMsgWhenCaughtByPX} " +
+                this.HttpContext.Items[PaymentConstants.Web.InstrumentManagementProperties.Message] = $"{GlobalConstants.AbnormalDetection.LogMsgWhenCaughtByPX} " +
                     $"by flight {Flighting.Features.PXChallengeSwitch}. Missing currentContext for Add CreditCard request with AccountId: {accountId}";
                 return this.Request.CreateResponse(HttpStatusCode.BadRequest, serviceErrorResp, GlobalConstants.HeaderValues.JsonContent);
             }

--- a/net8/migration/PXService.NetStandard/Controllers/PaymentMethodDescriptionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/PaymentMethodDescriptionsController.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
@@ -236,7 +235,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
         public async Task<List<PIDLResource>> GetByFamilyAndType(
-            [FromUri] string accountId,
+            string accountId,
             string family,
             string type = null,
             string country = null,
@@ -639,7 +638,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
         public async Task<List<PIDLResource>> SelectPaymentResource(
-            [FromUri] string accountId,
+            string accountId,
             string country = null,
             string language = null,
             string partner = Constants.ServiceDefaults.DefaultPartnerName,
@@ -938,7 +937,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
         public async Task<List<PIDLResource>> GetByFamilyAndTypeWithCompletePrerequisitesOption(
-            [FromUri] string accountId,
+            string accountId,
             string country,
             string family,
             bool completePrerequisites,
@@ -3732,9 +3731,9 @@ namespace Microsoft.Commerce.Payments.PXService.V7
             qrCodeContext.QrCodeCreatedTime = DateTime.UtcNow;
             qrCodeContext.AllowTestHeader = false;
 
-            IEnumerable<string> testHeader = null;
-            this.Request.Headers.TryGetValues(PaymentConstants.PaymentExtendedHttpHeaders.TestHeader, out testHeader);
-            if (this.ExposedFlightFeatures.Contains(V7.Constants.PartnerFlightValues.PXCOTTestAccounts, StringComparer.OrdinalIgnoreCase) || (testHeader != null && testHeader.Contains(Constants.TestAccountHeaders.MDollarPurchase)))
+            Microsoft.Extensions.Primitives.StringValues testHeader;
+            this.Request.Headers.TryGetValue(PaymentConstants.PaymentExtendedHttpHeaders.TestHeader, out testHeader);
+            if (this.ExposedFlightFeatures.Contains(V7.Constants.PartnerFlightValues.PXCOTTestAccounts, StringComparer.OrdinalIgnoreCase) || testHeader.Contains(Constants.TestAccountHeaders.MDollarPurchase))
             {
                 qrCodeContext.AllowTestHeader = true; 
             }

--- a/net8/migration/PXService.NetStandard/Controllers/PaymentRequestsExController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/PaymentRequestsExController.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
 {
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common.Web;
     using Microsoft.Commerce.Payments.Common;
     using Microsoft.Commerce.Payments.Common.Tracing;
@@ -27,7 +27,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         [HttpPost]
         public async Task<HttpResponseMessage> AttachChallengeData(
             [FromBody] PIDLData paymentInstrument,
-            [FromUri] string paymentRequestId)
+            string paymentRequestId)
         {
             const string CvvTokenPath = "cvvToken";
             const string PiIdPath = "piId";
@@ -69,7 +69,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         [HttpPost]
         public async Task<HttpResponseMessage> RemoveEligiblePaymentmethods(
             [FromBody] PIDLData paymentInstrument,
-            [FromUri] string paymentRequestId)
+            string paymentRequestId)
         {
             const string PiIdPath = "piid";
 

--- a/net8/migration/PXService.NetStandard/Controllers/PaymentSessionDescriptionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/PaymentSessionDescriptionsController.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;
@@ -28,7 +28,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Returns a PaymentSession PIDL for the given PaymentSessionData</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
-        public async Task<List<PIDLResource>> Get([FromUri]string accountId, [FromUri]string paymentSessionData)
+        public async Task<List<PIDLResource>> Get(string accountId, string paymentSessionData)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             PaymentSessionData paymentSessionDataObj = JsonConvert.DeserializeObject<PaymentSessionData>(paymentSessionData);

--- a/net8/migration/PXService.NetStandard/Controllers/PaymentSessionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/PaymentSessionsController.cs
@@ -11,8 +11,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
     using System.Net.Http.Headers;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
-    using System.Web;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Transaction;
@@ -50,7 +49,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns the created PaymentSession</returns>
         [HttpPost]
         [ActionName("PostPaymentSession")]
-        public async Task<PaymentSession> Post([FromUri]string accountId)
+        public async Task<PaymentSession> Post(string accountId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -99,7 +98,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <param name="sessionId">Session Id</param>
         /// <returns>Returns queried PaymentSession that matches the session and account id</returns>
         [HttpGet]
-        public async Task<HttpResponseMessage> GetPaymentSession([FromUri] string accountId, [FromUri] string sessionId)
+        public async Task<HttpResponseMessage> GetPaymentSession(string accountId, string sessionId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -238,7 +237,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns payment instrument or payment instrument status used for polling</returns>
         [HttpGet]
         [ActionName("qrCodeStatus")]
-        public async Task<Microsoft.Commerce.Payments.PimsModel.V4.PaymentInstrument> GetQRCodePaymentSession([FromUri] string accountId, [FromUri] string sessionId)
+        public async Task<Microsoft.Commerce.Payments.PimsModel.V4.PaymentInstrument> GetQRCodePaymentSession(string accountId, string sessionId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -336,7 +335,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns AuthenticationResponse</returns>
         [HttpPost]
         [ActionName("Authenticate")]
-        public async Task<AuthenticationResponse> Authenticate([FromUri] string accountId, [FromUri] string sessionId)
+        public async Task<AuthenticationResponse> Authenticate(string accountId, string sessionId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             string payload = await this.Request.GetRequestPayload();
@@ -373,7 +372,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns the created PaymentSession</returns>
         [HttpPost]
         [ActionName("CreateAndAuthenticate")]
-        public async Task<CreateAndAuthenticateResponse> CreateAndAuthenticate([FromUri] string accountId)
+        public async Task<CreateAndAuthenticateResponse> CreateAndAuthenticate(string accountId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             string payload = await this.Request.GetRequestPayload();
@@ -446,7 +445,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns the created PaymentSession</returns>
         [HttpPost]
         [ActionName("NotifyThreeDSChallengeCompleted")]
-        public async Task<HttpResponseMessage> NotifyThreeDSChallengeCompleted([FromUri] string accountId, [FromUri] string sessionId)
+        public async Task<HttpResponseMessage> NotifyThreeDSChallengeCompleted(string accountId, string sessionId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -468,7 +467,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns the created PaymentSession</returns>
         [HttpPost]
         [ActionName("BrowserAuthenticate")]
-        public async Task<HttpResponseMessage> Authenticate([FromUri] string sessionId)
+        public async Task<HttpResponseMessage> Authenticate(string sessionId)
         {
             ClientAction nextAction = null;
             try
@@ -648,7 +647,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
 
         [HttpPost]
         [ActionName("BrowserNotifyThreeDSChallengeCompleted")]
-        public async Task<HttpResponseMessage> NotifyThreeDSChallengeCompleted([FromUri] string sessionId)
+        public async Task<HttpResponseMessage> NotifyThreeDSChallengeCompleted(string sessionId)
         {
             ClientAction clientAction = null;
             try
@@ -743,8 +742,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         [HttpPost]
         [ActionName("BrowserAuthenticateThreeDSOne")]
         public async Task<HttpResponseMessage> BrowserAuthenticateThreeDSOne(
-            [FromUri] string accountId,
-            [FromUri] string sessionId,
+            string accountId,
+            string sessionId,
             [FromBody] PIDLData cvvChallengePayload)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -939,7 +938,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns the HTML that does a POST to ACS Url</returns>
         [HttpGet]
         [ActionName("BrowserAuthenticateRedirectionThreeDSOne")]
-        public async Task<HttpResponseMessage> BrowserAuthenticateRedirectionThreeDSOne([FromUri] string sessionId, string ru, string rx)
+        public async Task<HttpResponseMessage> BrowserAuthenticateRedirectionThreeDSOne(string sessionId, string ru, string rx)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -974,7 +973,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
 
         [HttpPost]
         [ActionName("BrowserNotifyThreeDSOneChallengeCompleted")]
-        public async Task<HttpResponseMessage> BrowserNotifyThreeDSOneChallengeCompleted([FromUri] string sessionId)
+        public async Task<HttpResponseMessage> BrowserNotifyThreeDSOneChallengeCompleted(string sessionId)
         {
             Uri redirectUrl;
 
@@ -1037,7 +1036,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns RDS URL</returns>
         [HttpPost]
         [ActionName("AuthenticateIndiaThreeDS")]
-        public async Task<HttpResponseMessage> AuthenticateIndiaThreeDS([FromUri] string accountId, [FromUri] string sessionId, [FromBody] PIDLData cvvChallengePayload)
+        public async Task<HttpResponseMessage> AuthenticateIndiaThreeDS(string accountId, string sessionId, [FromBody] PIDLData cvvChallengePayload)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -1134,7 +1133,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// False if the challenge was failed or its status is unknown.</returns>
         [HttpGet]
         [ActionName("AuthenticationStatus")]
-        public async Task<HttpResponseMessage> AuthenticationStatus([FromUri] string accountId, [FromUri] string sessionId, [FromUri] string piId, [FromUri] string paymentContext = null)
+        public async Task<HttpResponseMessage> AuthenticationStatus(string accountId, string sessionId, string piId, string paymentContext = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 

--- a/net8/migration/PXService.NetStandard/Controllers/PaymentTransactionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/PaymentTransactionsController.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentTransaction
     using System.Net.Http;
     using System.Text.Json;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common;
     using Common.Tracing;
     using Common.Web;
@@ -86,10 +86,10 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentTransaction
         /// shipped and hence funds have been authorized but not captured yet.)</returns>
         [HttpGet]
         public async Task<PaymentTransactions> ListTransactions(
-            [FromUri] string accountId,
-            [FromUri] string continuationToken = null,
-            [FromUri] string[] status = null,
-            [FromUri] ulong deviceId = 0,
+            string accountId,
+            string continuationToken = null,
+            string[] status = null,
+            ulong deviceId = 0,
             string language = "en",
             string partner = V7.Constants.ServiceDefaults.DefaultPartnerName,
             string country = null)
@@ -112,7 +112,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentTransaction
         /// indicating if the associated PI should be blocked from deletion (e.g. a hardware order which has not yet
         /// shipped and hence funds have been authorized but not captured yet.)</returns>
         [HttpPost]
-        public async Task<HttpResponseMessage> ListTransactions([FromUri] string accountId, [FromUri] string country, [FromUri] string language, [FromUri] string partner, [FromBody] PIDLData requestData)
+        public async Task<HttpResponseMessage> ListTransactions(string accountId, string country, string language, string partner, [FromBody] PIDLData requestData)
         {
             // NOTE Add traces and logs
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.NetStandard/Controllers/PidlTransformationController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/PidlTransformationController.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Commerce.Payments.PXService.V7
 {
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PidlFactory.V7;

--- a/net8/migration/PXService.NetStandard/Controllers/PidlValidationController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/PidlValidationController.cs
@@ -2,13 +2,13 @@
 
 namespace Microsoft.Commerce.Payments.PXService.V7
 {
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PidlFactory.V7;
     using Microsoft.Commerce.Payments.PidlModel.V7;
 
-    public class PidlValidationController : ApiController
+    public class PidlValidationController : ControllerBase
     {
         /// <summary>
         /// Pidl Validation

--- a/net8/migration/PXService.NetStandard/Controllers/ProfileDescriptionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/ProfileDescriptionsController.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;
@@ -36,7 +36,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
-        public async Task<List<PIDLResource>> GetByCountry([FromUri]string accountId, string country, string type, string operation = Constants.Operations.Add, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string scenario = null)
+        public async Task<List<PIDLResource>> GetByCountry(string accountId, string country, string type, string operation = Constants.Operations.Add, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string scenario = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             accountId = accountId + string.Empty;

--- a/net8/migration/PXService.NetStandard/Controllers/RDSSessionController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/RDSSessionController.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common.Tracing;
     using Common.Web;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;
@@ -34,7 +34,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A rds Status Pidl</response>
         /// <returns>A rds Status Pidl</returns>
         [HttpPost]
-        public async Task<HttpResponseMessage> Query([FromBody]PIDLData sessionDetails, [FromUri]string sessionId = null, [FromUri] string piid = null, [FromUri] string partner = null, [FromUri] string language = null, [FromUri] string country = null, [FromUri] string scenario = null)
+        public async Task<HttpResponseMessage> Query([FromBody]PIDLData sessionDetails, string sessionId = null, string piid = null, string partner = null, string language = null, string country = null, string scenario = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 

--- a/net8/migration/PXService.NetStandard/Controllers/RewardsDescriptionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/RewardsDescriptionsController.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;
@@ -40,13 +40,13 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
         public async Task<List<PIDLResource>> Get(
-            [FromUri] string accountId,
-            [FromUri] string type,
-            [FromUri] string operation,
-            [FromUri] string country = null,
-            [FromUri] string language = null,
-            [FromUri] string partner = Constants.ServiceDefaults.DefaultPartnerName,
-            [FromUri] string rewardsContextData = null)
+            string accountId,
+            string type,
+            string operation,
+            string country = null,
+            string language = null,
+            string partner = Constants.ServiceDefaults.DefaultPartnerName,
+            string rewardsContextData = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 

--- a/net8/migration/PXService.NetStandard/Controllers/SessionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/SessionsController.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.IdentityModel.Tokens.Jwt;
     using System.Security.Claims;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PXCommon;
@@ -29,7 +29,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A session object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
-        public async Task<SecondScreenSessionData> GetBySessionId([FromUri]string sessionId)
+        public async Task<SecondScreenSessionData> GetBySessionId(string sessionId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -57,7 +57,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A session object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpPost]
-        public string PostBySessionId([FromUri]string sessionId)
+        public string PostBySessionId(string sessionId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             return sessionId;

--- a/net8/migration/PXService.NetStandard/Controllers/SettingsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/SettingsController.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.IO;
     using System.Net;
     using System.Net.Http;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.Pidl.Localization;
@@ -38,7 +38,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A setting object</response>
         /// <returns>A setting object</returns>
         [HttpGet]
-        public HttpResponseMessage GetSettings([FromUri]string appName, [FromUri]string appVersion, [FromUri] string language = null)
+        public HttpResponseMessage GetSettings(string appName, string appVersion, string language = null)
         {
             if (string.Equals(appName, Constants.AppDetails.WalletPackageName, StringComparison.OrdinalIgnoreCase))
             {
@@ -86,7 +86,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A setting object</response>
         /// <returns>A setting object</returns>
         [HttpPost]
-        public ServerSettingResponse GetSettingsInPost([FromUri] string accountId, [FromBody] ClientConfigData clientConfigData)
+        public ServerSettingResponse GetSettingsInPost(string accountId, [FromBody] ClientConfigData clientConfigData)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 

--- a/net8/migration/PXService.NetStandard/Controllers/TaxIdDescriptionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/TaxIdDescriptionsController.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;
@@ -31,7 +31,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
-        public List<PIDLResource> Get([FromUri]string accountId, string country, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string type = null)
+        public List<PIDLResource> Get(string accountId, string country, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string type = null)
         {
             // Use Partner Settings if enabled for the partner
             PaymentExperienceSetting setting = this.GetPaymentExperienceSetting(Constants.Operations.Add);
@@ -57,7 +57,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
-        public List<PIDLResource> GetStandaloneTaxPidl([FromUri]string accountId, string country, string operation, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string type = null, string scenario = null)
+        public List<PIDLResource> GetStandaloneTaxPidl(string accountId, string country, string operation, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string type = null, string scenario = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             accountId = accountId + string.Empty;

--- a/net8/migration/PXService.NetStandard/Controllers/TenantDescriptionsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/TenantDescriptionsController.cs
@@ -4,13 +4,13 @@ namespace Microsoft.Commerce.Payments.PXService.V7
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PidlFactory.V7;
     using Microsoft.Commerce.Payments.PidlModel.V7;
 
-    public class TenantDescriptionsController : ApiController
+    public class TenantDescriptionsController : ControllerBase
     {
         /// <summary>
         /// Get Tenant Descriptions 
@@ -27,7 +27,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
-        public List<PIDLResource> Get([FromUri]string accountId, string type, string country, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName)
+        public List<PIDLResource> Get(string accountId, string type, string country, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             accountId = accountId + string.Empty;

--- a/net8/migration/PXService.NetStandard/Controllers/TokensExController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/TokensExController.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common.Web;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;
@@ -39,7 +39,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpPost]
-        public async Task<HttpResponseMessage> Tokens([FromBody] PIDLData payload, [FromUri] string accountId, string partner, string piid, string country, string language)
+        public async Task<HttpResponseMessage> Tokens([FromBody] PIDLData payload, string accountId, string partner, string piid, string country, string language)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
             PaymentExperienceSetting setting = this.GetPaymentExperienceSetting(V7.Constants.Operations.Get);
@@ -136,7 +136,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpPost]
-        public async Task<HttpResponseMessage> PostChallenge([FromBody] PIDLData payload, [FromUri] string accountId, [FromUri] string ntid, [FromUri] string challengeId, string country, string language, string partner)
+        public async Task<HttpResponseMessage> PostChallenge([FromBody] PIDLData payload, string accountId, string ntid, string challengeId, string country, string language, string partner)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -189,7 +189,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpPost]
-        public async Task<HttpResponseMessage> ValidateChallenge([FromBody] PIDLData payload, [FromUri] string accountId, [FromUri] string ntid, [FromUri] string challengeId, string country, string language, string partner, string challengeMethodId)
+        public async Task<HttpResponseMessage> ValidateChallenge([FromBody] PIDLData payload, string accountId, string ntid, string challengeId, string country, string language, string partner, string challengeMethodId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 
@@ -241,7 +241,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpPost]
-        public async Task<HttpResponseMessage> Mandates([FromBody] PIDLData payload, [FromUri] string accountId, [FromUri] string ntid)
+        public async Task<HttpResponseMessage> Mandates([FromBody] PIDLData payload, string accountId, string ntid)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
 

--- a/net8/migration/PXService.NetStandard/Controllers/WalletsController.cs
+++ b/net8/migration/PXService.NetStandard/Controllers/WalletsController.cs
@@ -8,8 +8,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Common.Web;
     using Microsoft.Commerce.Payments.PidlFactory.V7;
     using Microsoft.Commerce.Payments.PimsModel.V4;
@@ -118,7 +117,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Returns session id</returns>
         [HttpPost]
         public async Task<HttpResponseMessage> ProvisionWalletToken(
-            [FromUri] string accountId,
+            string accountId,
             [FromBody] ProvisionWalletTokenIncomingPayload payload)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.NetStandard/Handlers/PXChallengeManagementHandler.cs
+++ b/net8/migration/PXService.NetStandard/Handlers/PXChallengeManagementHandler.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PXChallengeManagement
     using System.Diagnostics.Eventing.Reader;
     using System.Linq;
     using System.Threading.Tasks;
-    using System.Web;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PidlFactory.V7;


### PR DESCRIPTION
## Summary
- update controllers to use ASP.NET Core MVC conventions
- add helper extensions for HttpRequest and remove legacy System.Web usage
- replace System.Web utilities in handlers with ASP.NET Core equivalents

## Testing
- `dotnet build net8/migration/PXService.NetStandard/PXService.NetStandard.csproj` *(fails: OperationContractAttribute not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e2cf197a08329a44e11a369d0c8ef