### PR TITLE
Add CoreWCF sample hosting and config

### DIFF
--- a/net8/migration/PXService.NetStandard/PXService.NetStandard.csproj
+++ b/net8/migration/PXService.NetStandard/PXService.NetStandard.csproj
@@ -5,9 +5,17 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="CoreWCF.ConfigurationManager" Version="1.8.0" />
+    <PackageReference Include="CoreWCF.Http" Version="1.8.0" />
+    <PackageReference Include="CoreWCF.Primitives" Version="1.8.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters.CoreServices" Version="2.0.0" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Update="wcf.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" />

--- a/net8/migration/PXService.NetStandard/Program.cs
+++ b/net8/migration/PXService.NetStandard/Program.cs
@@ -1,17 +1,20 @@
+using CoreWCF;
+using CoreWCF.Configuration;
+using PXService.NetStandard.Services;
+
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSystemWebAdapters();
 builder.Services.AddHttpForwarder();
 
-// Add services to the container.
+builder.Services.AddServiceModelServices()
+                .AddServiceModelConfigurationManagerFile("wcf.config");
 
 builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -19,9 +22,13 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
-
 app.UseAuthorization();
 app.UseSystemWebAdapters();
+
+app.UseServiceModel(serviceBuilder =>
+{
+    serviceBuilder.AddService<SampleService>();
+});
 
 app.MapControllers();
 app.MapForwarder("/{**catch-all}", app.Configuration["ProxyTo"]).Add(static builder => ((RouteEndpointBuilder)builder).Order = int.MaxValue);

--- a/net8/migration/PXService.NetStandard/Services/SampleService.cs
+++ b/net8/migration/PXService.NetStandard/Services/SampleService.cs
@@ -1,0 +1,15 @@
+using CoreWCF;
+
+namespace PXService.NetStandard.Services;
+
+[ServiceContract]
+public interface ISampleService
+{
+    [OperationContract]
+    string Echo(string text);
+}
+
+public class SampleService : ISampleService
+{
+    public string Echo(string text) => $"Echo: {text}";
+}

--- a/net8/migration/PXService.NetStandard/wcf.config
+++ b/net8/migration/PXService.NetStandard/wcf.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.serviceModel>
+    <services>
+      <service name="PXService.NetStandard.Services.SampleService">
+        <endpoint address="" binding="basicHttpBinding" contract="PXService.NetStandard.Services.ISampleService" />
+      </service>
+    </services>
+  </system.serviceModel>
+</configuration>


### PR DESCRIPTION
## Summary
- add CoreWCF packages and WCF configuration to PXService.NetStandard
- host a sample CoreWCF service using wcf.config

## Testing
- `dotnet build PXService.NetStandard.csproj` *(fails: OperationContractAttribute not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e32bbd97c83299d5ada5c33bb6e79