### PR TITLE
refactor: use ValidationAttribute for output-only properties

### DIFF
--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Account.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Account.cs
@@ -86,20 +86,20 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 
         #region output properties, must be null or default value when this type is used for input
 
-        [OutputProperty(Tag = "Account.Status")]
+        [OutputProperty]
         [DataMember]
         public AccountStatus? Status { get; set; }
 
-        [OutputProperty(Tag = "Account.CreatedDate")]
+        [OutputProperty]
         [DataMember]
         public DateTime CreatedDate { get; set; }
 
-        [OutputProperty(Tag = "Account.LastUpdatedDate")]
+        [OutputProperty]
         [DataMember]
         public DateTime LastUpdatedDate { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
-        [OutputProperty(Tag = "Account.Violation")]
+        [OutputProperty]
         [ObjectCollectionValidator(typeof(Violation), Tag = "Account.Violation")]
         [DataMember]
         public List<Violation> Violations { get; set; }

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/PayinAccount.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/PayinAccount.cs
@@ -68,27 +68,27 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public List<Phone> PhoneSet { get; set; }
 
-        [OutputProperty(Tag = "PayinAccount.AnniversaryDate")]
+        [OutputProperty]
         [DataMember]
         public int AnniversaryDate { get; set; }
 
-        [OutputProperty(Tag = "PayinAccount.DefaultAddressID")]
+        [OutputProperty]
         [DataMember]
         public string DefaultAddressID { get; set; }
 
-        [OutputProperty(Tag = "PayinAccount.CorporateIdentity")]
+        [OutputProperty]
         [DataMember]
         public string CorporateIdentity { get; set; }
 
-        [OutputProperty(Tag = "PayinAccount.CorporateLegalEntity")]
+        [OutputProperty]
         [DataMember]
         public string CorporateLegalEntity { get; set; }
 
-        [OutputProperty(Tag = "PayinAccount.CorporateVatId")]
+        [OutputProperty]
         [DataMember]
         public string CorporateVatId { get; set; }
 
-        [OutputProperty(Tag = "PayinAccount.CorporateAddress")]
+        [OutputProperty]
         [DataMember]
         public Address CorporateAddress { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Violation.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Violation.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public int ViolationID { get; set; }
 
-        [OutputProperty(Tag = "Violation.Name")]
+        [OutputProperty]
         [DataMember]
         public string Name { get; set; }
     }


### PR DESCRIPTION
## Summary
- replace Enterprise Library `OutputPropertyAttribute` with a `ValidationAttribute` enforcing null/default values
- update data models to use new attribute

## Testing
- `dotnet build net8/migration/PXService.NetStandard/PXService.NetStandard.sln` *(fails: System.ServiceModel types missing)*

------
https://chatgpt.com/codex/tasks/task_e_688e56477ec08329994dbf51c83fab0f