### PR TITLE
Replace Enterprise Library validators with DataAnnotations

### DIFF
--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/APIContext.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/APIContext.cs
@@ -23,14 +23,14 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         public Guid TrackingGuid { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
-        [ObjectCollectionValidator(typeof(Property), Tag = "APIContext")]
-        [PropertyCollectionValidator(Tag = "APIContext")]
+        [ObjectCollectionValidator(typeof(Property))]
+        [PropertyCollectionValidator]
         [DataMember]
         public List<Property> PropertyBag { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
-        [ObjectCollectionValidator(typeof(Property), Tag = "APIContext")]
-        [PropertyCollectionValidator(Tag = "APIContext")]
+        [ObjectCollectionValidator(typeof(Property))]
+        [PropertyCollectionValidator]
         [DataMember]
         public List<Property> FraudDetectionContext { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Account.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Account.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using System.Collections.Generic;
     using System.Runtime.Serialization;
     using System.Xml.Serialization;
+    using System.ComponentModel.DataAnnotations;
     using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
     [DataContract(Namespace = NamespaceConstants.Namespace)]
@@ -55,28 +56,33 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public string AccountRole { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(64, Tag = "Account.FriendlyName")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "Account.FriendlyName")]
+        [IgnoreNulls]
+        [StringLength(64)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string FriendlyName { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(129, Tag = "Account.Email")]
-        [RegexValidator(RegexConstants.Email, Tag = "Account.Email")]
+        [IgnoreNulls]
+        [StringLength(129)]
+        [RegularExpression(RegexConstants.Email)]
         [DataMember]
         public string Email { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(5, 11, Tag = "Account.Locale")]
-        [RegexValidator(RegexConstants.Locale, Tag = "Account.Locale")]
+        [IgnoreNulls]
+        [StringLength(11, MinimumLength = 5)]
+        [RegularExpression(RegexConstants.Locale)]
         [DataMember]
         public string Locale { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(3, 3, Tag = "Account.Currency")]
-        [RegexValidator(RegexConstants.Currency, Tag = "Account.Currency")]
+        [IgnoreNulls]
+        [StringLength(3, MinimumLength = 3)]
+        [RegularExpression(RegexConstants.Currency)]
         [DataMember]
         public string Currency { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(2, 2, Tag = "Account.CountryCode")]
-        [RegexValidator(RegexConstants.CountryCode, Tag = "Account.CountryCode")]
+        [IgnoreNulls]
+        [StringLength(2, MinimumLength = 2)]
+        [RegularExpression(RegexConstants.CountryCode)]
         [DataMember]
         public string CountryCode { get; set; }
 
@@ -100,7 +106,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
         [OutputProperty]
-        [ObjectCollectionValidator(typeof(Violation), Tag = "Account.Violation")]
+        [ObjectCollectionValidator(typeof(Violation))]
         [DataMember]
         public List<Violation> Violations { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/AccountSearchCriteria.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/AccountSearchCriteria.cs
@@ -3,6 +3,7 @@
 namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.DataModel
 {
     using System.Runtime.Serialization;
+    using System.ComponentModel.DataAnnotations;
     using Microsoft.Practices.EnterpriseLibrary.Validation;
     using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
@@ -19,13 +20,12 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         }
         #endregion
 
-        [IgnoreNulls, StringLengthValidator(16, 16,
-            MessageTemplate = "AccountId:{0} must be 16 characters",
-            Tag = "AccountSearchCriteria.AccountID")]
+        [IgnoreNulls]
+        [StringLength(16, MinimumLength = 16)]
         [DataMember]
         public string AccountId { get; set; }
 
-        [ObjectValidator(Tag = "AccountSearchCriteria.Identity")]
+        [ObjectValidator]
         [DataMember]
         public Identity Identity { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Address.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Address.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 {
     using System;
     using System.Runtime.Serialization;
+    using System.ComponentModel.DataAnnotations;
     using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
     using System.Collections.Generic;
 
@@ -20,12 +21,14 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         }
         #endregion
 
-        [IgnoreNulls, StringLengthValidator(16, 16, Tag = "Address.AddressID")]
+        [IgnoreNulls]
+        [StringLength(16, MinimumLength = 16)]
         [DataMember]
         public string AddressID { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(64, Tag = "Address.FriendlyName")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "Address.FriendlyName")]
+        [IgnoreNulls]
+        [StringLength(64)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string FriendlyName { get; set; }
 
@@ -45,51 +48,59 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public string CompanyNamePronunciation { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(0, 15, Tag = "Address.UnitNumber")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "Address.UnitNumber")]
+        [IgnoreNulls]
+        [StringLength(15)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string UnitNumber { get; set; }
 
-        [StringLengthValidator(1, 128, Tag = "Address.Street1")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "Address.Street1")]
+        [StringLength(128, MinimumLength = 1)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string Street1 { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(128, Tag = "Address.Street2")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "Address.Street2")]
+        [IgnoreNulls]
+        [StringLength(128)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string Street2 { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(128, Tag = "Address.Street3")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "Address.Street3")]
+        [IgnoreNulls]
+        [StringLength(128)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string Street3 { get; set; }
 
-        [StringLengthValidator(1, 64, Tag = "Address.City")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "Address.City")]
+        [StringLength(64, MinimumLength = 1)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string City { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(64, Tag = "Address.District")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "Address.District")]
+        [IgnoreNulls]
+        [StringLength(64)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string District { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(64, Tag = "Address.State")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "Address.State")]
+        [IgnoreNulls]
+        [StringLength(64)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string State { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(2, 2, Tag = "Address.CountryCode")]
-        [RegexValidator(RegexConstants.CountryCode, Tag = "Address.CountryCode")]
+        [IgnoreNulls]
+        [StringLength(2, MinimumLength = 2)]
+        [RegularExpression(RegexConstants.CountryCode)]
         [DataMember]
         public string CountryCode { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(16, Tag = "Address.PostalCode")]
+        [IgnoreNulls]
+        [StringLength(16)]
         [DataMember]
         public string PostalCode { get; set; }
 
-        [IgnoreNulls, ObjectValidator(Tag = "Address.MapAddressResult")]
+        [IgnoreNulls]
+        [ObjectValidator]
         [DataMember]
         public MapAddressResult MapAddressResult { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/CallerInfo.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/CallerInfo.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 {
     using System;
     using System.Runtime.Serialization;
+    using System.ComponentModel.DataAnnotations;
     using Microsoft.Practices.EnterpriseLibrary.Validation;
     using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
@@ -19,18 +20,16 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         }
         #endregion
 
-        [ObjectValidator(Tag = "CallerInfo")]
+        [ObjectValidator]
         [DataMember]
         public Identity Delegator { get; set; }
 
-        [ObjectValidator(Tag = "CallerInfo")]
+        [ObjectValidator]
         [DataMember]
         public Identity Requester { get; set; }
 
         [IgnoreNulls]
-        [StringLengthValidator(16, 16,
-            MessageTemplate = "AccountId:{0} must be 16 characters",
-            Tag = "CallerInfo")]
+        [StringLength(16, MinimumLength = 16)]
         [DataMember]
         public string AccountId { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Identity.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Identity.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using System.Collections.Generic;
     using System.Linq;
     using System.Runtime.Serialization;
+    using System.ComponentModel.DataAnnotations;
     using Microsoft.Practices.EnterpriseLibrary.Validation;
     using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
@@ -24,15 +25,11 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         }
         #endregion
 
-        [StringLengthValidator(0, 32,
-            MessageTemplate = "IdentityType:{0} must be between 0 and 32 characters",
-            Tag = "Identity")]
+        [StringLength(32)]
         [DataMember]
         public string IdentityType { get; set; }
 
-        [StringLengthValidator(1, 64,
-            MessageTemplate = "IdentityValue:{0} must be between 1 and 64 characters",
-            Tag = "Identity")]
+        [StringLength(64, MinimumLength = 1)]
         [DataMember]
         public string IdentityValue { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/PayinAccount.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/PayinAccount.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 {
     using System.Collections.Generic;
     using System.Runtime.Serialization;
+    using System.ComponentModel.DataAnnotations;
     using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
     [DataContract(Namespace = NamespaceConstants.Namespace)]
@@ -28,43 +29,51 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         public CustomerType? CustomerType { get; set; }
 
 
-        [IgnoreNulls, StringLengthValidator(64, Tag = "PayinAccount.FirstName")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "PayinAccount.FirstName")]
+        [IgnoreNulls]
+        [StringLength(64)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string FirstName { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(64, Tag = "PayinAccount.FirstNamePronunciation")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "PayinAccount.FirstNamePronunciation")]
+        [IgnoreNulls]
+        [StringLength(64)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string FirstNamePronunciation { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(64, Tag = "PayinAccount.LastName")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "PayinAccount.LastName")]
+        [IgnoreNulls]
+        [StringLength(64)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string LastName { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(64, Tag = "PayinAccount.LastNamePronunciation")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "PayinAccount.LastNamePronunciation")]
+        [IgnoreNulls]
+        [StringLength(64)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string LastNamePronunciation { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(64, Tag = "PayinAccount.CompanyName")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "PayinAccount.CompanyName")]
+        [IgnoreNulls]
+        [StringLength(64)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string CompanyName { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(64, Tag = "PayinAccount.CompanyNamePronunciation")]
-        [RegexValidator(RegexConstants.XmlString, Tag = "PayinAccount.CompanyNamePronunciation")]
+        [IgnoreNulls]
+        [StringLength(64)]
+        [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string CompanyNamePronunciation { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
-        [IgnoreNulls, ElementNotNull, ObjectCollectionValidator(typeof(Address), Tag = "PayinAccount.AddressSet")]
+        [Required]
+        [ObjectCollectionValidator(typeof(Address))]
         [DataMember]
         public List<Address> AddressSet { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
-        [IgnoreNulls, ElementNotNull, ObjectCollectionValidator(typeof(Phone), Tag = "PayinAccount.PhoneSet")]
+        [Required]
+        [ObjectCollectionValidator(typeof(Phone))]
         [DataMember]
         public List<Phone> PhoneSet { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Phone.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Phone.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 {
     using System;
     using System.Runtime.Serialization;
+    using System.ComponentModel.DataAnnotations;
     using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
     [DataContract(Namespace = NamespaceConstants.Namespace)]
@@ -40,20 +41,24 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public PhoneType? PhoneType { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(12, Tag = "Phone.PhonePrefix")]
+        [IgnoreNulls]
+        [StringLength(12)]
         [DataMember]
         public string PhonePrefix { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(32, Tag = "Phone.PhoneNumber")]
+        [IgnoreNulls]
+        [StringLength(32)]
         [DataMember]
         public string PhoneNumber { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(12, Tag = "Phone.PhoneExtension")]
+        [IgnoreNulls]
+        [StringLength(12)]
         [DataMember]
         public string PhoneExtension { get; set; }
 
-        [IgnoreNulls, StringLengthValidator(2, 2, Tag = "Phone.CountryCode")]
-        [RegexValidator(RegexConstants.CountryCode, Tag = "Phone.CountryCode")]
+        [IgnoreNulls]
+        [StringLength(2, MinimumLength = 2)]
+        [RegularExpression(RegexConstants.CountryCode)]
         [DataMember]
         public string CountryCode { get; set; }
     }

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Property.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Property.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 {
     using System;
     using System.Runtime.Serialization;
+    using System.ComponentModel.DataAnnotations;
     using Microsoft.Practices.EnterpriseLibrary.Validation;
     using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
@@ -22,15 +23,15 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         }
         #endregion
 
-        [NotNullValidator(Tag = "Property")]
+        [Required]
         [DataMember]
         public string Namespace { get; set; }
 
-        [NotNullValidator(Tag = "Property")]
+        [Required]
         [DataMember]
         public string Name { get; set; }
 
-        [NotNullValidator(Tag = "Property")]
+        [Required]
         [DataMember]
         public string Value { get; set; }
 


### PR DESCRIPTION
## Summary
- migrate data models from Enterprise Library validators to System.ComponentModel.DataAnnotations equivalents
- drop Tag parameters from collection and object validators

## Testing
- `dotnet build net8/migration/PXService.NetStandard/PXService.NetStandard.sln` *(fails: OperationContractAttribute missing)*

------
https://chatgpt.com/codex/tasks/task_e_688e5850b8b08329bef511cfff545c8d