### PR TITLE
Remove IgnoreNulls attributes from DataModel

### DIFF
--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Account.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Account.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using System.Runtime.Serialization;
     using System.Xml.Serialization;
     using System.ComponentModel.DataAnnotations;
-    using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
     [DataContract(Namespace = NamespaceConstants.Namespace)]
     public enum AccountStatus
@@ -56,31 +55,26 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public string AccountRole { get; set; }
 
-        [IgnoreNulls]
         [StringLength(64)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string FriendlyName { get; set; }
 
-        [IgnoreNulls]
         [StringLength(129)]
         [RegularExpression(RegexConstants.Email)]
         [DataMember]
         public string Email { get; set; }
 
-        [IgnoreNulls]
         [StringLength(11, MinimumLength = 5)]
         [RegularExpression(RegexConstants.Locale)]
         [DataMember]
         public string Locale { get; set; }
 
-        [IgnoreNulls]
         [StringLength(3, MinimumLength = 3)]
         [RegularExpression(RegexConstants.Currency)]
         [DataMember]
         public string Currency { get; set; }
 
-        [IgnoreNulls]
         [StringLength(2, MinimumLength = 2)]
         [RegularExpression(RegexConstants.CountryCode)]
         [DataMember]
@@ -106,7 +100,6 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
         [OutputProperty]
-        [ObjectCollectionValidator(typeof(Violation))]
         [DataMember]
         public List<Violation> Violations { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/AccountSearchCriteria.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/AccountSearchCriteria.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using System.Runtime.Serialization;
     using System.ComponentModel.DataAnnotations;
     using Microsoft.Practices.EnterpriseLibrary.Validation;
-    using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
     [HasSelfValidation]
     [DataContract(Namespace = NamespaceConstants.Namespace)]
@@ -20,12 +19,10 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         }
         #endregion
 
-        [IgnoreNulls]
         [StringLength(16, MinimumLength = 16)]
         [DataMember]
         public string AccountId { get; set; }
 
-        [ObjectValidator]
         [DataMember]
         public Identity Identity { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Address.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Address.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using System;
     using System.Runtime.Serialization;
     using System.ComponentModel.DataAnnotations;
-    using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
     using System.Collections.Generic;
 
     [DataContract(Namespace = NamespaceConstants.Namespace), Serializable]
@@ -21,12 +20,10 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         }
         #endregion
 
-        [IgnoreNulls]
         [StringLength(16, MinimumLength = 16)]
         [DataMember]
         public string AddressID { get; set; }
 
-        [IgnoreNulls]
         [StringLength(64)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
@@ -48,7 +45,6 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public string CompanyNamePronunciation { get; set; }
 
-        [IgnoreNulls]
         [StringLength(15)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
@@ -59,13 +55,11 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public string Street1 { get; set; }
 
-        [IgnoreNulls]
         [StringLength(128)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string Street2 { get; set; }
 
-        [IgnoreNulls]
         [StringLength(128)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
@@ -76,31 +70,25 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public string City { get; set; }
 
-        [IgnoreNulls]
         [StringLength(64)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string District { get; set; }
 
-        [IgnoreNulls]
         [StringLength(64)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string State { get; set; }
 
-        [IgnoreNulls]
         [StringLength(2, MinimumLength = 2)]
         [RegularExpression(RegexConstants.CountryCode)]
         [DataMember]
         public string CountryCode { get; set; }
 
-        [IgnoreNulls]
         [StringLength(16)]
         [DataMember]
         public string PostalCode { get; set; }
 
-        [IgnoreNulls]
-        [ObjectValidator]
         [DataMember]
         public MapAddressResult MapAddressResult { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/CallerInfo.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/CallerInfo.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using System.Runtime.Serialization;
     using System.ComponentModel.DataAnnotations;
     using Microsoft.Practices.EnterpriseLibrary.Validation;
-    using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
     [DataContract(Namespace = NamespaceConstants.Namespace)]
     public class CallerInfo : IExtensibleDataObject
@@ -20,15 +19,12 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         }
         #endregion
 
-        [ObjectValidator]
         [DataMember]
         public Identity Delegator { get; set; }
 
-        [ObjectValidator]
         [DataMember]
         public Identity Requester { get; set; }
 
-        [IgnoreNulls]
         [StringLength(16, MinimumLength = 16)]
         [DataMember]
         public string AccountId { get; set; }

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/PayinAccount.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/PayinAccount.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using System.Collections.Generic;
     using System.Runtime.Serialization;
     using System.ComponentModel.DataAnnotations;
-    using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
     [DataContract(Namespace = NamespaceConstants.Namespace)]
     public enum CustomerType
@@ -24,42 +23,35 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     [DataContract(Namespace = NamespaceConstants.Namespace)]
     public class PayinAccount : Account, IExtensibleDataObject
     {
-        [IgnoreNulls]
         [DataMember]
         public CustomerType? CustomerType { get; set; }
 
 
-        [IgnoreNulls]
         [StringLength(64)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string FirstName { get; set; }
 
-        [IgnoreNulls]
         [StringLength(64)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string FirstNamePronunciation { get; set; }
 
-        [IgnoreNulls]
         [StringLength(64)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string LastName { get; set; }
 
-        [IgnoreNulls]
         [StringLength(64)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string LastNamePronunciation { get; set; }
 
-        [IgnoreNulls]
         [StringLength(64)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
         public string CompanyName { get; set; }
 
-        [IgnoreNulls]
         [StringLength(64)]
         [RegularExpression(RegexConstants.XmlString)]
         [DataMember]
@@ -67,13 +59,11 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
         [Required]
-        [ObjectCollectionValidator(typeof(Address))]
         [DataMember]
         public List<Address> AddressSet { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
         [Required]
-        [ObjectCollectionValidator(typeof(Phone))]
         [DataMember]
         public List<Phone> PhoneSet { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Phone.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Phone.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using System;
     using System.Runtime.Serialization;
     using System.ComponentModel.DataAnnotations;
-    using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
 
     [DataContract(Namespace = NamespaceConstants.Namespace)]
     public enum PhoneType
@@ -37,26 +36,21 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         }
         #endregion
 
-        [IgnoreNulls]
         [DataMember]
         public PhoneType? PhoneType { get; set; }
 
-        [IgnoreNulls]
         [StringLength(12)]
         [DataMember]
         public string PhonePrefix { get; set; }
 
-        [IgnoreNulls]
         [StringLength(32)]
         [DataMember]
         public string PhoneNumber { get; set; }
 
-        [IgnoreNulls]
         [StringLength(12)]
         [DataMember]
         public string PhoneExtension { get; set; }
 
-        [IgnoreNulls]
         [StringLength(2, MinimumLength = 2)]
         [RegularExpression(RegexConstants.CountryCode)]
         [DataMember]


### PR DESCRIPTION
## Summary
- drop Enterprise Library `[IgnoreNulls]` annotations from LegacyCommerceService data model classes
- clean up `Microsoft.Practices.EnterpriseLibrary.Validation.Validators` usage

## Testing
- `dotnet build` *(fails: OperationContractAttribute not found in System.ServiceModel)*

------
https://chatgpt.com/codex/tasks/task_e_688e6087d8bc83299d9ed7afb56ba809