### PR TITLE
Replace self validation attributes with IValidatableObject

### DIFF
--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Account.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Account.cs
@@ -19,13 +19,12 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         Closed = 5,
     }
 
-    [HasSelfValidation]
     [KnownType(typeof(PayinAccount))]
     [KnownType(typeof(PayoutAccount))]
     [XmlInclude(typeof(PayinAccount))]
     [XmlInclude(typeof(PayoutAccount))]
     [DataContract(Namespace = NamespaceConstants.Namespace)]
-    public class Account : IExtensibleDataObject
+    public class Account : IExtensibleDataObject, IValidatableObject
     {
         #region IExtensibleDataObject members
         protected ExtensionDataObject _extensionData;
@@ -127,6 +126,10 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
                 BdkId bdk = new BdkId(AccountID);
                 _billableAccountID = bdk.AccountId;
             }
+        }
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            yield break;
         }
     }
 }

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Property.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Property.cs
@@ -5,13 +5,11 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using System;
     using System.Runtime.Serialization;
     using System.ComponentModel.DataAnnotations;
-    using Microsoft.Practices.EnterpriseLibrary.Validation;
-    using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
+    using System.Collections.Generic;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716", Justification = "Legacy code moved from PCS. Needed for serialization")]
-    [HasSelfValidation]
     [DataContract(Namespace = NamespaceConstants.Namespace), Serializable]
-    public class Property : IExtensibleDataObject
+    public class Property : IExtensibleDataObject, IValidatableObject
     {
         #region IExtensibleDataObject members
         [NonSerialized]
@@ -35,17 +33,13 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public string Value { get; set; }
 
-        [SelfValidation]
-        public void Validate(ValidationResults results)
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             if (string.IsNullOrEmpty(Namespace) && string.IsNullOrEmpty(Name))
             {
-                results.AddResult(new ValidationResult(
+                yield return new ValidationResult(
                     "Namespace and Name in a Property can not be both empty.",
-                    this,
-                    "Namespace and Name",
-                    "Property",
-                    null));
+                    new[] { nameof(Namespace), nameof(Name) });
             }
         }
     }

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Violation.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Violation.cs
@@ -3,11 +3,11 @@
 namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.DataModel
 {
     using System.Runtime.Serialization;
-    using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
+    using System.ComponentModel.DataAnnotations;
+    using System.Collections.Generic;
 
-    [HasSelfValidation]
     [DataContract(Namespace = NamespaceConstants.Namespace)]
-    public class Violation : IExtensibleDataObject
+    public class Violation : IExtensibleDataObject, IValidatableObject
     {
         #region IExtensibleDataObject members
         private ExtensionDataObject _extensionData;
@@ -24,5 +24,10 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [OutputProperty]
         [DataMember]
         public string Name { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            yield break;
+        }
     }
 }

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/Messages/CreateAccountRequest.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/Messages/CreateAccountRequest.cs
@@ -7,10 +7,11 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using System.Xml.Serialization;
     using Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.DataModel;
     using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
+    using System.ComponentModel.DataAnnotations;
+    using System.Collections.Generic;
 
-    [HasSelfValidation]
     [DataContract(Namespace = NamespaceConstants.Namespace)]
-    public class CreateAccountRequest : AbstractRequest
+    public class CreateAccountRequest : AbstractRequest, IValidatableObject
     {
         public override int ApiId
         {
@@ -36,6 +37,11 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         public override Guid EffectiveTrackingGuid
         {
             get { return APIContext == null ? Guid.Empty : APIContext.TrackingGuid; }
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            yield break;
         }
     }
 }

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/Messages/GetAccountInfoRequest.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/Messages/GetAccountInfoRequest.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.DataModel;
     using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
     using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
 
-    [HasSelfValidation]
     [DataContract(Namespace = NamespaceConstants.Namespace)]
-    public class GetAccountInfoRequest : AbstractRequest
+    public class GetAccountInfoRequest : AbstractRequest, IValidatableObject
     {
         public override int ApiId
         {
@@ -82,6 +82,11 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         public override Guid EffectiveTrackingGuid
         {
             get { return APIContext == null ? Guid.Empty : APIContext.TrackingGuid; }
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            yield break;
         }
     }
 }

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/Messages/UpdateAccountRequest.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/Messages/UpdateAccountRequest.cs
@@ -7,10 +7,11 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
     using System.Xml.Serialization;
     using Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.DataModel;
     using Microsoft.Practices.EnterpriseLibrary.Validation.Validators;
+    using System.ComponentModel.DataAnnotations;
+    using System.Collections.Generic;
 
-    [HasSelfValidation]
     [DataContract(Namespace = NamespaceConstants.Namespace)]
-    public class UpdateAccountRequest : AbstractRequest
+    public class UpdateAccountRequest : AbstractRequest, IValidatableObject
     {
         public override int ApiId
         {
@@ -36,6 +37,11 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         public override Guid EffectiveTrackingGuid
         {
             get { return APIContext == null ? Guid.Empty : APIContext.TrackingGuid; }
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            yield break;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace EnterpriseLibrary HasSelfValidation with DataAnnotations IValidatableObject across legacy commerce models and requests
- migrate SelfValidation logic into Validate methods

## Testing
- `dotnet test PXService.NetStandard.sln` *(fails: Missing referenced project)*

------
https://chatgpt.com/codex/tasks/task_e_688e6260abc4832993c6183be4c36320