### PR TITLE
Refactor custom validators to DataAnnotations

### DIFF
--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/APIContext.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/APIContext.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
     using System.Runtime.Serialization;
 
     [DataContract(Namespace = NamespaceConstants.Namespace)]
@@ -22,15 +23,18 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         public Guid TrackingGuid { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
-        // TODO: validate PropertyBag items
+        [ElementNotNull]
+        [PropertyCollectionValidator]
         [DataMember]
         public List<Property> PropertyBag { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
-        // TODO: validate FraudDetectionContext items
+        [ElementNotNull]
+        [PropertyCollectionValidator]
         [DataMember]
         public List<Property> FraudDetectionContext { get; set; }
 
+        [ValidateComplexType]
         [DataMember]
         public DeviceInfo DeviceInfo { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Account.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Account.cs
@@ -80,6 +80,8 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         public string CountryCode { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819", Justification = "Legacy code moved from PCS. Needed for serialization")]
+        [ElementNotNull]
+        [PropertyCollectionValidator]
         [DataMember]
         public Property[] CustomPropertiesField { get; set; }
 
@@ -99,7 +101,8 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
         [OutputProperty]
-        // TODO: validate Violations items
+        [ElementNotNull]
+        [ValidateComplexType]
         [DataMember]
         public List<Violation> Violations { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/AccountSearchCriteria.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/AccountSearchCriteria.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public string AccountId { get; set; }
 
-        // TODO: validate Identity
+        [ValidateComplexType]
         [DataMember]
         public Identity Identity { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Address.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/Address.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         [DataMember]
         public string PostalCode { get; set; }
 
-        // TODO: validate MapAddressResult
+        [ValidateComplexType]
         [DataMember]
         public MapAddressResult MapAddressResult { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/CallerInfo.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/CallerInfo.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         }
         #endregion
 
-        // TODO: validate Delegator
+        [ValidateComplexType]
         [DataMember]
         public Identity Delegator { get; set; }
 
-        // TODO: validate Requester
+        [ValidateComplexType]
         [DataMember]
         public Identity Requester { get; set; }
 

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/ElementNotNullValidator.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/ElementNotNullValidator.cs
@@ -1,0 +1,28 @@
+namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.DataModel
+{
+    using System;
+    using System.Collections;
+    using System.ComponentModel.DataAnnotations;
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class ElementNotNullAttribute : ValidationAttribute
+    {
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+        {
+            if (value is IEnumerable enumerable)
+            {
+                int index = 0;
+                foreach (var element in enumerable)
+                {
+                    if (element is null)
+                    {
+                        var memberName = validationContext.MemberName ?? validationContext.DisplayName;
+                        return new ValidationResult($"{memberName} contains a null element at index {index}.", new[] { memberName });
+                    }
+                    index++;
+                }
+            }
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/PayinAccount.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/PayinAccount.cs
@@ -59,13 +59,15 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
         [Required]
-        // TODO: validate AddressSet items
+        [ElementNotNull]
+        [ValidateComplexType]
         [DataMember]
         public List<Address> AddressSet { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
         [Required]
-        // TODO: validate PhoneSet items
+        [ElementNotNull]
+        [ValidateComplexType]
         [DataMember]
         public List<Phone> PhoneSet { get; set; }
 
@@ -94,6 +96,8 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         public Address CorporateAddress { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227", Justification = "Legacy code. Should be thrown away once modernAPI is available")]
+        [ElementNotNull]
+        [ValidateComplexType]
         [DataMember]
         public List<TaxExemption> TaxExemptionSet { get; set; }
     }

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/PropertyCollectionValidator.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/PropertyCollectionValidator.cs
@@ -1,0 +1,39 @@
+namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.DataModel
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class PropertyCollectionValidatorAttribute : ValidationAttribute
+    {
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+        {
+            if (value is IEnumerable enumerable)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    if (item is null)
+                    {
+                        var memberName = validationContext.MemberName ?? validationContext.DisplayName;
+                        return new ValidationResult($"{memberName} contains a null element at index {index}.", new[] { memberName });
+                    }
+
+                    var context = new ValidationContext(item);
+                    var results = new List<ValidationResult>();
+                    if (!Validator.TryValidateObject(item, context, results, true))
+                    {
+                        var first = results.First();
+                        string? memberName = validationContext.MemberName != null ? $"{validationContext.MemberName}[{index}]" : null;
+                        return new ValidationResult(first.ErrorMessage, new[] { memberName });
+                    }
+                    index++;
+                }
+            }
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/SubscriptionsInfo.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/SubscriptionsInfo.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
     using System.Runtime.Serialization;
 
     [DataContract(Namespace = NamespaceConstants.Namespace)]
@@ -506,6 +507,8 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.LegacyCommerceService.
         public MetaData MetaData { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Legacy code")]
+        [ElementNotNull]
+        [PropertyCollectionValidator]
         [DataMember]
         public Property[] PropertyBag { get; set; }
 


### PR DESCRIPTION
## Summary
- add ElementNotNull and PropertyCollectionValidator attributes based on ValidationAttribute
- annotate collections and complex types with new attributes and ValidateComplexType

## Testing
- `dotnet build` *(fails: missing System.ServiceModel references)*

------
https://chatgpt.com/codex/tasks/task_e_688e8fff122883299cdc3c4db9048017