### PR TITLE
Add WCF client dependencies and custom validation attribute

### DIFF
--- a/net8/migration/PXService.NetStandard/Directory.Packages.props
+++ b/net8/migration/PXService.NetStandard/Directory.Packages.props
@@ -135,9 +135,11 @@
 		<ItemGroup>
 			<PackageVersion Include="CoreWCF.ConfigurationManager" Version="1.8.0" />
 			<PackageVersion Include="CoreWCF.Http" Version="1.8.0" />
-			<PackageVersion Include="CoreWCF.Primitives" Version="1.8.0" />
-			<PackageVersion Include="Microsoft.AspNetCore.SystemWebAdapters.CoreServices" Version="2.0.0" />
-			<PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.0" />
-			<PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
-		</ItemGroup>
+                        <PackageVersion Include="CoreWCF.Primitives" Version="1.8.0" />
+                        <PackageVersion Include="System.ServiceModel.Primitives" Version="7.0.0" />
+                        <PackageVersion Include="System.ServiceModel.Http" Version="7.0.0" />
+                        <PackageVersion Include="Microsoft.AspNetCore.SystemWebAdapters.CoreServices" Version="2.0.0" />
+                        <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+                        <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
+                </ItemGroup>
 </Project>

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/CTPCommerceDataAccessor.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/CTPCommerceDataAccessor.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Commerce.Payments.PXService
 
         public Messages.GetSubscriptionsResponse GetSubscriptions(Messages.GetSubscriptionsRequest request, EventTraceActivity traceActivityId)
         {
-            return this.Execute<Messages.GetSubscriptionsRequest, Messages.GetSubscriptionsResponse, GetSubscriptionsRequest, GetSubscriptionsResponse>
+            return this.Execute<Messages.GetSubscriptionsRequest, Messages.GetSubscriptionsResponse, Proxy.GetSubscriptionsRequest, Proxy.GetSubscriptionsResponse>
                 (
                     type: DataAccessorType.GetSubscriptions,
                     request: request,
@@ -46,12 +46,12 @@ namespace Microsoft.Commerce.Payments.PXService
                 );
         }
 
-        private GetSubscriptionsRequest ConstructGetSubscriptionsInput(Messages.GetSubscriptionsRequest request)
+        private Proxy.GetSubscriptionsRequest ConstructGetSubscriptionsInput(Messages.GetSubscriptionsRequest request)
         {
             if (request == null)
                 return null;
 
-            GetSubscriptionsRequest input = new GetSubscriptionsRequest();
+            var input = new Proxy.GetSubscriptionsRequest();
             if (request.Requester != null)
             {
                 input.Requester = new Proxy.Identity()
@@ -61,7 +61,7 @@ namespace Microsoft.Commerce.Payments.PXService
                 };
             }
             input.SubscriptionId = request.SubscriptionId;
-            input.DetailLevel = (GetSubscriptionsDetailLevel)request.DetailLevel;
+            input.DetailLevel = (Proxy.GetSubscriptionsDetailLevel)request.DetailLevel;
             input.GetSubscriptionsOfAllPartners = request.GetSubscriptionsOfAllPartners;
             input.PagingOption = request.PagingOption == null ? null : BuildPagingOption(request.PagingOption);
             input.OrderBy = request.OrderBy == null ? null : BuilidOrderBy(request.OrderBy).ToArray();

--- a/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/ValidateComplexTypeAttribute.cs
+++ b/net8/migration/PXService.NetStandard/LegacyCommerceService/DataModel/ValidateComplexTypeAttribute.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace System.ComponentModel.DataAnnotations
+{
+    /// <summary>
+    /// A minimal replacement for the ASP.NET Core ValidateComplexTypeAttribute.
+    /// Validates the object graph of the decorated property using DataAnnotations.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    internal sealed class ValidateComplexTypeAttribute : ValidationAttribute
+    {
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+        {
+            if (value is null)
+            {
+                return ValidationResult.Success;
+            }
+
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(value, new ValidationContext(value), results, validateAllProperties: true);
+            return results.Count == 0 ? ValidationResult.Success : new ValidationResult(validationContext.DisplayName + " is invalid");
+        }
+    }
+}
+

--- a/net8/migration/PXService.NetStandard/PXService.NetStandard.csproj
+++ b/net8/migration/PXService.NetStandard/PXService.NetStandard.csproj
@@ -8,6 +8,8 @@
     <PackageReference Include="CoreWCF.ConfigurationManager" />
     <PackageReference Include="CoreWCF.Http" />
     <PackageReference Include="CoreWCF.Primitives" />
+    <PackageReference Include="System.ServiceModel.Primitives" />
+    <PackageReference Include="System.ServiceModel.Http" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters.CoreServices" />
     <PackageReference Include="Yarp.ReverseProxy" />


### PR DESCRIPTION
## Summary
- add System.ServiceModel client packages and central versions
- implement ValidateComplexTypeAttribute using DataAnnotations
- fix CTPCommerceDataAccessor to reference proxy GetSubscriptions types

## Testing
- `dotnet restore`
- `dotnet build` *(fails: Common.csproj, PidlFactory.csproj, PidlModel.csproj, PimsModel.csproj, PXCommon.csproj not found; unresolved EventTraceActivity)*

------
https://chatgpt.com/codex/tasks/task_e_688d972f9d20832989692726ec154bc8