### PR TITLE
chore: centralize .NET 8 package versions

### DIFF
--- a/net8/migration/Directory.Packages.props
+++ b/net8/migration/Directory.Packages.props
@@ -136,10 +136,10 @@
 			<PackageVersion Include="CoreWCF.ConfigurationManager" Version="1.8.0" />
 			<PackageVersion Include="CoreWCF.Http" Version="1.8.0" />
                         <PackageVersion Include="CoreWCF.Primitives" Version="1.8.0" />
-                        <PackageVersion Include="System.ServiceModel.Primitives" Version="7.0.0" />
-                        <PackageVersion Include="System.ServiceModel.Http" Version="7.0.0" />
-                        <PackageVersion Include="Microsoft.AspNetCore.SystemWebAdapters.CoreServices" Version="2.0.0" />
-                        <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.0" />
-                        <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
+                          <PackageVersion Include="System.ServiceModel.Primitives" Version="8.1.2" />
+                          <PackageVersion Include="System.ServiceModel.Http" Version="8.1.2" />
+                          <PackageVersion Include="Microsoft.AspNetCore.SystemWebAdapters.CoreServices" Version="2.0.0" />
+                          <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+                          <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
                 </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- centralize package version management for migration projects
- update WCF and Swagger packages for .NET 8 support

## Testing
- `dotnet restore`
- `dotnet build` *(fails: missing project references and types)*

------
https://chatgpt.com/codex/tasks/task_e_688f19faa7588329bde56c9685f93168