### PR TITLE
refactor: replace System.Web routing with ASP.NET Core equivalents

### DIFF
--- a/net8/migration/PXService.Web/PXServiceApiVersionHandler.cs
+++ b/net8/migration/PXService.Web/PXServiceApiVersionHandler.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
-    using System.Web.Http.Routing;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Routing;
     using Microsoft.Commerce.Payments.Common;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;
@@ -60,16 +61,7 @@ namespace Microsoft.Commerce.Payments.PXService
         /// <returns>The outbound response.</returns>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            IHttpRouteData routeData;
-            if (!WebHostingUtility.IsApplicationSelfHosted())
-            {
-                routeData = request.GetRouteData();
-            }
-            else
-            {
-                // We get the route data differently for selfhosted environment. This enables the /probe route.
-                routeData = request.GetConfiguration().Routes.GetRouteData(request);
-            }
+            RouteData? routeData = request.GetHttpContext()?.GetRouteData();
 
             object controller;
             bool allowedVersionlessRequest =

--- a/net8/migration/PXService.Web/PXServicePIDLValidationHandler.cs
+++ b/net8/migration/PXService.Web/PXServicePIDLValidationHandler.cs
@@ -9,7 +9,8 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
-    using System.Web.Http.Routing;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Routing;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PXCommon;
@@ -60,17 +61,7 @@ namespace Microsoft.Commerce.Payments.PXService
 
             try
             {
-                IHttpRouteData routeData;
-
-                if (!WebHostingUtility.IsApplicationSelfHosted())
-                {
-                    routeData = request.GetRouteData();
-                }
-                else
-                {
-                    // We get the route data differently for selfhosted environment
-                    routeData = request.GetConfiguration().Routes.GetRouteData(request);
-                }
+                RouteData? routeData = request.GetHttpContext()?.GetRouteData();
 
                 object controller;
                 HttpContent content = response.Content;


### PR DESCRIPTION
## Summary
- use HttpContext-based routing in PXServiceApiVersionHandler
- use HttpContext-based routing in PXServicePIDLValidationHandler

## Testing
- `dotnet build net8/migration/PXService.Web/PXService.csproj` *(fails: FromUri not found in PXService.NetStandard)*

------
https://chatgpt.com/codex/tasks/task_e_688fddcc42fc8329a51d59ae99b9b1cd