### PR TITLE
Add HttpRequest helpers and replace HttpUtility

### DIFF
--- a/net8/migration/PXService.Web/Controllers/CheckoutsExController.cs
+++ b/net8/migration/PXService.Web/Controllers/CheckoutsExController.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.Checkouts
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Text.Encodings.Web;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Commerce.Payments.Common;
@@ -67,7 +68,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.Checkouts
             else if (!string.IsNullOrEmpty(providerId) && providerId.Equals(Constants.PaymentProviderIds.Stripe, System.StringComparison.OrdinalIgnoreCase))
             {
                 clientAction.ActionId = checkoutId;
-                string jsEncodedClientAction = HttpUtility.JavaScriptStringEncode(JsonConvert.SerializeObject(clientAction));
+                string jsEncodedClientAction = JavaScriptEncoder.Default.Encode(JsonConvert.SerializeObject(clientAction));
                 responseContent = string.Format(PostMessageHtmlTemplate, jsEncodedClientAction);
             }
 

--- a/net8/migration/PXService.Web/Controllers/HttpRequestExtensions.cs
+++ b/net8/migration/PXService.Web/Controllers/HttpRequestExtensions.cs
@@ -1,8 +1,12 @@
 namespace Microsoft.Commerce.Payments.PXService.V7
 {
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Text;
+    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
     using Newtonsoft.Json;
 
@@ -32,6 +36,38 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         public static HttpResponseMessage CreateErrorResponse(this HttpRequest request, HttpStatusCode statusCode, object error)
         {
             return request.CreateResponse(statusCode, error);
+        }
+
+        public static IEnumerable<KeyValuePair<string, string>> GetQueryNameValuePairs(this HttpRequest request)
+        {
+            return request.Query.Select(q => new KeyValuePair<string, string>(q.Key, q.Value));
+        }
+
+        public static bool TryGetQueryParameterValue(this HttpRequest request, string parameterName, out string value, string pattern = null)
+        {
+            if (request.Query.TryGetValue(parameterName, out var values))
+            {
+                value = values.FirstOrDefault();
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public static async Task<string> GetRequestPayload(this HttpRequest request)
+        {
+            if (request.ContentLength == null || request.ContentLength == 0)
+            {
+                return string.Empty;
+            }
+
+            request.EnableBuffering();
+            request.Body.Position = 0;
+            using var reader = new StreamReader(request.Body, leaveOpen: true);
+            var payload = await reader.ReadToEndAsync();
+            request.Body.Position = 0;
+            return payload;
         }
     }
 }

--- a/net8/migration/PXService.Web/Controllers/HttpResponseException.cs
+++ b/net8/migration/PXService.Web/Controllers/HttpResponseException.cs
@@ -1,0 +1,21 @@
+namespace Microsoft.Commerce.Payments.PXService.V7
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+
+    public class HttpResponseException : Exception
+    {
+        public HttpResponseMessage Response { get; }
+
+        public HttpResponseException(HttpResponseMessage response)
+        {
+            this.Response = response;
+        }
+
+        public HttpResponseException(HttpStatusCode statusCode)
+        {
+            this.Response = new HttpResponseMessage(statusCode);
+        }
+    }
+}

--- a/net8/migration/PXService.Web/Controllers/PaymentInstrumentsExController.cs
+++ b/net8/migration/PXService.Web/Controllers/PaymentInstrumentsExController.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Text;
+    using System.Text.Encodings.Web;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Mvc;
@@ -1682,7 +1683,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
 
         private static HttpResponseMessage ComposeHtmlPostMessageResponse(ClientAction clientAction)
         {
-            string jsEncodedClientAction = HttpUtility.JavaScriptStringEncode(JsonConvert.SerializeObject(clientAction));
+            string jsEncodedClientAction = JavaScriptEncoder.Default.Encode(JsonConvert.SerializeObject(clientAction));
             string responseContent = string.Format(PostMessageHtmlTemplate, jsEncodedClientAction);
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
             response.Content = new StringContent(responseContent);

--- a/net8/migration/PXService.Web/Controllers/PaymentSessionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/PaymentSessionsController.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Text.Encodings.Web;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Mvc;
@@ -1382,7 +1383,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
 
         private static HttpResponseMessage ComposeHtmlPostMessageResponse(ClientAction clientAction)
         {
-            string jsEncodedClientAction = HttpUtility.JavaScriptStringEncode(JsonConvert.SerializeObject(clientAction));
+            string jsEncodedClientAction = JavaScriptEncoder.Default.Encode(JsonConvert.SerializeObject(clientAction));
             string responseContent = string.Format(PostMessageHtmlTemplate, jsEncodedClientAction);
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
             response.Content = new StringContent(responseContent);


### PR DESCRIPTION
## Summary
- extend HttpRequest helper to parse query strings and payloads
- add minimal HttpResponseException for Web API compatibility
- replace HttpUtility with JavaScriptEncoder

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689064cacaf4832991572e8fccd4aecc