### PR TITLE
Fix missing extensions and request handling for PXDependencyEmulators

### DIFF
--- a/net8/migration/PXDependencyEmulators/Controllers/AccountAddressesController.cs
+++ b/net8/migration/PXDependencyEmulators/Controllers/AccountAddressesController.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Cont
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Net.Http;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
 using FromUri = Microsoft.AspNetCore.Mvc.FromQueryAttribute;
     using Constants = Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Constants;
@@ -82,12 +83,11 @@ using FromUri = Microsoft.AspNetCore.Mvc.FromQueryAttribute;
             return this.ReplacePlaceholders(resp);
         }
 
-        private static bool IsValidateAddressWithAVSFlightExposed(HttpRequestMessage request)
+        private static bool IsValidateAddressWithAVSFlightExposed(HttpRequest request)
         {
-            IEnumerable<string> headerValues;
-            if (request.Headers.TryGetValues(Test.Common.Constants.HeaderValues.ExtendedFlightName, out headerValues))
+            if (request.Headers.TryGetValue(Test.Common.Constants.HeaderValues.ExtendedFlightName, out var headerValues))
             {
-                string xMSFlightValue = headerValues.FirstOrDefault();
+                var xMSFlightValue = headerValues.FirstOrDefault();
                 return xMSFlightValue != null && xMSFlightValue.Contains(Test.Common.Constants.FlightValues.AccountEmulatorValidateAddressWithAVS);
             }
 

--- a/net8/migration/PXDependencyEmulators/Extensions/ScenarioManagerExtensions.cs
+++ b/net8/migration/PXDependencyEmulators/Extensions/ScenarioManagerExtensions.cs
@@ -1,0 +1,13 @@
+namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Extensions
+{
+    using Common.Transaction;
+    using System.Net.Http;
+
+    public static class ScenarioManagerExtensions
+    {
+        public static HttpResponseMessage GetResponse(this IScenarioManager manager, string apiName, TestContext testContext)
+        {
+            return manager.GetMockResponse(apiName, testContext);
+        }
+    }
+}

--- a/net8/migration/PXDependencyEmulators/Extensions/ServiceProviderExtensions.cs
+++ b/net8/migration/PXDependencyEmulators/Extensions/ServiceProviderExtensions.cs
@@ -1,0 +1,14 @@
+namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Extensions
+{
+    using System;
+    using Microsoft.Extensions.DependencyInjection;
+    
+    public static class ServiceProviderExtensions
+    {
+        public static IScenarioManager GetTestScenarioManager(this IServiceProvider provider, string key)
+        {
+            var registry = provider.GetRequiredService<IScenarioManagerRegistry>();
+            return registry.GetManager(key);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add GetTestScenarioManager extension for `IServiceProvider`
- provide `GetResponse` extension to fetch mock responses from scenario managers
- refactor `AccountAddressesController` to use ASP.NET Core `HttpRequest` header APIs

## Testing
- `dotnet build net8/migration/PXDependencyEmulators/PXDependencyEmulators.csproj` *(fails: missing TestContext/AReq etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68911aca8db48329ba625b63ff9a145f