### PR TITLE
Add scenario manager interfaces and extensions

### DIFF
--- a/net8/migration/PXDependencyEmulators/Controllers/EmulatorBaseController.cs
+++ b/net8/migration/PXDependencyEmulators/Controllers/EmulatorBaseController.cs
@@ -11,6 +11,7 @@ using FromUri = Microsoft.AspNetCore.Mvc.FromQueryAttribute;
     using Common.Web;
     using Test.Common;
     using Constants = Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Constants;
+    using Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Extensions;
 
     public class EmulatorBaseController : ControllerBase
     {
@@ -29,7 +30,7 @@ using FromUri = Microsoft.AspNetCore.Mvc.FromQueryAttribute;
 
         protected Dictionary<string, string> PlaceholderReplacements { get; }
 
-        protected TestScenarioManager TestScenarioManager
+        protected IScenarioManager TestScenarioManager
         {
             get
             {

--- a/net8/migration/PXDependencyEmulators/Controllers/FraudDetectionController.cs
+++ b/net8/migration/PXDependencyEmulators/Controllers/FraudDetectionController.cs
@@ -10,10 +10,11 @@ using FromUri = Microsoft.AspNetCore.Mvc.FromQueryAttribute;
     using Microsoft.Commerce.Payments.Common.Transaction;
     using Test.Common;
     using Constants = Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Constants;
+    using Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Extensions;
 
     public class FraudDetectionController : ControllerBase
     {
-        private TestScenarioManager TestScenarioManager
+        private IScenarioManager TestScenarioManager
         {
             get
             {

--- a/net8/migration/PXDependencyEmulators/Controllers/PimsPaymentInstrumentsController.cs
+++ b/net8/migration/PXDependencyEmulators/Controllers/PimsPaymentInstrumentsController.cs
@@ -10,6 +10,7 @@ using FromUri = Microsoft.AspNetCore.Mvc.FromQueryAttribute;
     using Common.Web;
     using Test.Common;
     using Constants = Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Constants;
+    using Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Extensions;
 
     public class PimsPaymentInstrumentsController : EmulatorBaseController
     {

--- a/net8/migration/PXDependencyEmulators/Controllers/PimsPaymentMethodsController.cs
+++ b/net8/migration/PXDependencyEmulators/Controllers/PimsPaymentMethodsController.cs
@@ -9,6 +9,7 @@ using FromUri = Microsoft.AspNetCore.Mvc.FromQueryAttribute;
     using Common.Web;
     using Test.Common;
     using Constants = Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Constants;
+    using Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Extensions;
 
     public class PimsPaymentMethodsController : EmulatorBaseController
     {

--- a/net8/migration/PXDependencyEmulators/Controllers/PurchaseController.cs
+++ b/net8/migration/PXDependencyEmulators/Controllers/PurchaseController.cs
@@ -13,6 +13,7 @@ using FromUri = Microsoft.AspNetCore.Mvc.FromQueryAttribute;
     using Common.Web;
     using Test.Common;
     using Constants = Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Constants;
+    using Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Extensions;
 
     public class PurchaseController : EmulatorBaseController
     {

--- a/net8/migration/PXDependencyEmulators/Extensions/TestScenarioManagerExtensions.cs
+++ b/net8/migration/PXDependencyEmulators/Extensions/TestScenarioManagerExtensions.cs
@@ -3,8 +3,13 @@ namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Exte
     using Common.Transaction;
     using System.Net.Http;
 
-    public static class ScenarioManagerExtensions
+    public static class TestScenarioManagerExtensions
     {
+        public static HttpResponseMessage GetResponse(this IScenarioManager manager, string apiName)
+        {
+            return manager.GetMockResponse(apiName);
+        }
+
         public static HttpResponseMessage GetResponse(this IScenarioManager manager, string apiName, TestContext testContext)
         {
             return manager.GetMockResponse(apiName, testContext);

--- a/net8/migration/PXDependencyEmulators/IScenarioManager.cs
+++ b/net8/migration/PXDependencyEmulators/IScenarioManager.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators
+{
+    using Common.Transaction;
+    using System.Net.Http;
+
+    public interface IScenarioManager
+    {
+        HttpResponseMessage GetMockResponse(string apiName);
+        HttpResponseMessage GetMockResponse(string apiName, TestContext testContext);
+    }
+}

--- a/net8/migration/PXDependencyEmulators/IScenarioManagerRegistry.cs
+++ b/net8/migration/PXDependencyEmulators/IScenarioManagerRegistry.cs
@@ -1,0 +1,7 @@
+namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators
+{
+    public interface IScenarioManagerRegistry
+    {
+        IScenarioManager GetManager(string key);
+    }
+}


### PR DESCRIPTION
## Summary
- add extension to retrieve scenario managers from DI
- allow scenario managers to produce mock responses via new extensions
- introduce interfaces for scenario managers and registry

## Testing
- `dotnet build` *(fails: TestContext could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68915440b5888329bebdc41a94a01178