### PR TITLE
Add scenario manager registry and DI extension

### DIFF
--- a/net8/migration/PXDependencyEmulators/Extensions/ServiceCollectionExtensions.cs
+++ b/net8/migration/PXDependencyEmulators/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Extensions
+{
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection RegisterScenarioManager(this IServiceCollection services, string key, IScenarioManager manager)
+        {
+            services.TryAddSingleton<ScenarioManagerRegistry>();
+            services.TryAddSingleton<IScenarioManagerRegistry>(sp => sp.GetRequiredService<ScenarioManagerRegistry>());
+
+            services.AddSingleton(sp =>
+            {
+                var registry = sp.GetRequiredService<ScenarioManagerRegistry>();
+                registry.RegisterScenarioManager(key, manager);
+                return manager;
+            });
+
+            return services;
+        }
+    }
+}

--- a/net8/migration/PXDependencyEmulators/ScenarioManagerRegistry.cs
+++ b/net8/migration/PXDependencyEmulators/ScenarioManagerRegistry.cs
@@ -1,0 +1,25 @@
+namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators
+{
+    using System;
+    using System.Collections.Concurrent;
+
+    public class ScenarioManagerRegistry : IScenarioManagerRegistry
+    {
+        private readonly ConcurrentDictionary<string, IScenarioManager> _managers = new(StringComparer.OrdinalIgnoreCase);
+
+        public IScenarioManager GetManager(string key)
+        {
+            if (_managers.TryGetValue(key, out var manager))
+            {
+                return manager;
+            }
+
+            throw new InvalidOperationException($"Scenario manager not registered for key '{key}'.");
+        }
+
+        public void RegisterScenarioManager(string key, IScenarioManager manager)
+        {
+            _managers[key] = manager;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ScenarioManagerRegistry` to store test scenario managers
- add `IServiceCollection.RegisterScenarioManager` extension for DI registration

## Testing
- `dotnet build PXDependencyEmulators.csproj -v minimal` *(fails: 94 errors)*


------
https://chatgpt.com/codex/tasks/task_e_68918325d35083299ce1fd8b42d75a1c