### PR TITLE
Fix emulator build configuration

### DIFF
--- a/net8/migration/PXDependencyEmulators/Controllers/PimsPaymentMethodsController.cs
+++ b/net8/migration/PXDependencyEmulators/Controllers/PimsPaymentMethodsController.cs
@@ -8,6 +8,7 @@ using FromUri = Microsoft.AspNetCore.Mvc.FromQueryAttribute;
     using Common.Transaction;
     using Common.Web;
     using Test.Common;
+    using Microsoft.Commerce.Payments.Common.Testing;
     using Constants = Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Constants;
     using Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Extensions;
 
@@ -39,7 +40,7 @@ using FromUri = Microsoft.AspNetCore.Mvc.FromQueryAttribute;
                 }
             }
 
-            return TestScenarioManager.GetResponse(apiName, testContext);
+            return this.TestScenarioManager.GetResponse(apiName, testContext);
         }
     }
 }

--- a/net8/migration/PXDependencyEmulators/Extensions/TestScenarioManagerExtensions.cs
+++ b/net8/migration/PXDependencyEmulators/Extensions/TestScenarioManagerExtensions.cs
@@ -1,6 +1,7 @@
 namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Extensions
 {
     using Common.Transaction;
+    using Microsoft.Commerce.Payments.Common.Testing;
     using System.Net.Http;
 
     public static class TestScenarioManagerExtensions

--- a/net8/migration/PXDependencyEmulators/PXDependencyEmulators.csproj
+++ b/net8/migration/PXDependencyEmulators/PXDependencyEmulators.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators</RootNamespace>
     <AssemblyName>Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators</AssemblyName>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>
 

--- a/net8/migration/PXDependencyEmulators/Program.cs
+++ b/net8/migration/PXDependencyEmulators/Program.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();


### PR DESCRIPTION
## Summary
- configure PXDependencyEmulators as executable and add minimal `Program.cs`
- add missing ScenarioManager extension references
- update PIMS payment methods controller to use scenario manager extension

## Testing
- `dotnet build net8/migration/PXDependencyEmulators/PXDependencyEmulators.csproj` *(fails: Duplicate 'System.Reflection.AssemblyCompanyAttribute' attribute, Error signing output with public key from file 'OCPKey.snk', and numerous missing type or namespace errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891a3711de88329915c8894c9d2a78a