### PR TITLE
fix: expose RegisterScenarioManager extension

### DIFF
--- a/net8/migration/PXDependencyEmulators/Extensions/ServiceCollectionExtensions.cs
+++ b/net8/migration/PXDependencyEmulators/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Extensions
+namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators
 {
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;


### PR DESCRIPTION
## Summary
- expose RegisterScenarioManager extension in root namespace so IServiceCollection can find it

## Testing
- `dotnet build net8/migration/PXDependencyEmulators/PXDependencyEmulators.csproj` *(fails: TestContext could not be found...)*


------
https://chatgpt.com/codex/tasks/task_e_689219f42dd483298c9bb654bc3dcb74