### PR TITLE
Add mock service request handlers for self-hosted PX tests

### DIFF
--- a/net8/migration/PXDependencyEmulators/Mocks/MockServiceDelegatingHandler.cs
+++ b/net8/migration/PXDependencyEmulators/Mocks/MockServiceDelegatingHandler.cs
@@ -1,0 +1,45 @@
+// <copyright file="MockServiceDelegatingHandler.cs" company="Microsoft">Copyright (c) Microsoft. All rights reserved.</copyright>
+
+namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Mocks
+{
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A delegating handler that allows tests to supply arranged responses for outbound
+    /// requests. If the <see cref="IMockResponseProvider"/> does not supply a response the
+    /// request is forwarded to the next handler in the pipeline.
+    /// </summary>
+    public class MockServiceDelegatingHandler : DelegatingHandler
+    {
+        private readonly IMockResponseProvider responseProvider;
+        private readonly bool useArrangedResponses;
+
+        public MockServiceDelegatingHandler(IMockResponseProvider responseProvider, bool useArrangedResponses)
+            : this(responseProvider, useArrangedResponses, new HttpClientHandler())
+        {
+        }
+
+        public MockServiceDelegatingHandler(IMockResponseProvider responseProvider, bool useArrangedResponses, HttpMessageHandler innerHandler)
+            : base(innerHandler)
+        {
+            this.responseProvider = responseProvider;
+            this.useArrangedResponses = useArrangedResponses;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (useArrangedResponses)
+            {
+                var arrangedResponse = await responseProvider.GetMatchedMockResponse(request);
+                if (arrangedResponse != null)
+                {
+                    return arrangedResponse;
+                }
+            }
+
+            return await base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/net8/migration/PXDependencyEmulators/Mocks/MockServiceWebRequestHandler.cs
+++ b/net8/migration/PXDependencyEmulators/Mocks/MockServiceWebRequestHandler.cs
@@ -1,0 +1,39 @@
+// <copyright file="MockServiceWebRequestHandler.cs" company="Microsoft">Copyright (c) Microsoft. All rights reserved.</copyright>
+
+namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Mocks
+{
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Generic HTTP handler used by the self-hosted PX service to mock dependent services.
+    /// It delegates to an <see cref="IMockResponseProvider"/> for arranged responses and
+    /// falls back to the default <see cref="HttpClientHandler"/> when no match is found.
+    /// </summary>
+    public class MockServiceWebRequestHandler : HttpClientHandler
+    {
+        private readonly IMockResponseProvider responseProvider;
+        private readonly bool useArrangedResponses;
+
+        public MockServiceWebRequestHandler(IMockResponseProvider responseProvider, bool useArrangedResponses)
+        {
+            this.responseProvider = responseProvider;
+            this.useArrangedResponses = useArrangedResponses;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (useArrangedResponses)
+            {
+                var arrangedResponse = await responseProvider.GetMatchedMockResponse(request);
+                if (arrangedResponse != null)
+                {
+                    return arrangedResponse;
+                }
+            }
+
+            return await base.SendAsync(request, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `MockServiceWebRequestHandler` to supply arranged responses for mock dependencies
- add companion `MockServiceDelegatingHandler`

## Testing
- `dotnet build net8/migration/SelfHostedPXServiceCore/SelfHostedPXServiceCore.csproj` *(fails: Projects that use central package version management should not define the version on the PackageReference items)*
- `dotnet build net8/migration/PXDependencyEmulators/PXDependencyEmulators.csproj` *(fails: Duplicate 'System.Reflection.AssemblyCompanyAttribute' attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68924c4587c48329984fef86bdd4a3ba