### PR TITLE
Use central package management for self-hosted service

### DIFF
--- a/net8/migration/Directory.Packages.props
+++ b/net8/migration/Directory.Packages.props
@@ -149,4 +149,11 @@
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="8.0.1" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.33" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="Castle.Core" Version="4.3.1" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.SelfHost" Version="5.2.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/net8/migration/SelfHostedPXServiceCore/SelfHostedPXServiceCore.csproj
+++ b/net8/migration/SelfHostedPXServiceCore/SelfHostedPXServiceCore.csproj
@@ -19,12 +19,12 @@
 
   <ItemGroup>
     <!-- Required packages for self hosted PX service -->
-    <PackageReference Include="Microsoft.AspNet.WebApi.SelfHost" Version="5.2.3" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.SelfHost" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="Castle.Core" Version="4.3.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Castle.Core" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- rely on central Directory.Packages.props for SelfHostedPXServiceCore dependencies
- register WebApi self-hosting packages and other dependencies in central package list

## Testing
- `dotnet restore net8/migration/SelfHostedPXServiceCore/SelfHostedPXServiceCore.csproj`
- `dotnet build net8/migration/SelfHostedPXServiceCore/SelfHostedPXServiceCore.csproj` *(fails: missing types)*


------
https://chatgpt.com/codex/tasks/task_e_689268ca18a88329826b78eb65d735ab