### PR TITLE
Fix build issues in SelfHostedPXServiceCore

### DIFF
--- a/net8/migration/SelfHostedPXServiceCore/HostableService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/HostableService.cs
@@ -44,7 +44,7 @@ namespace SelfHostedPXServiceCore
 
         public void Dispose()
         {
-            WebApp.Dispose();
+            WebApp.DisposeAsync().GetAwaiter().GetResult();
         }
     }
 }

--- a/net8/migration/SelfHostedPXServiceCore/Mocks/OrchestrationService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/Mocks/OrchestrationService.cs
@@ -2,8 +2,12 @@
 
 namespace SelfHostedPXServiceCore.Mocks
 {
+    using System;
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Commerce.Payments.Common.Tracing;
@@ -15,8 +19,23 @@ namespace SelfHostedPXServiceCore.Mocks
 
     public class OrchestrationService : MockServiceWebRequestHandler
     {
+        public List<string> Requests { get; } = new();
+
+        public Action<HttpRequestMessage>? PreProcess { get; set; }
+
+        public List<Response> Responses { get; } = new();
+
         public OrchestrationService(OrchestrationServiceMockResponseProvider resolver, bool useArrangedResponses) : base(resolver, useArrangedResponses)
         {
+        }
+
+        public class Response
+        {
+            public Func<HttpRequestMessage, bool> IsMatch { get; set; }
+
+            public HttpStatusCode StatusCode { get; set; }
+
+            public string Content { get; set; }
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -39,7 +58,7 @@ namespace SelfHostedPXServiceCore.Mocks
                     Content = new StringContent(
                             content: foundMatch.Content,
                             encoding: System.Text.Encoding.UTF8,
-                            mediaType: "application/json")
+                            mediaType: new MediaTypeHeaderValue("application/json"))
                 };
             }
 

--- a/net8/migration/SelfHostedPXServiceCore/SelfHostedPXServiceCore.csproj
+++ b/net8/migration/SelfHostedPXServiceCore/SelfHostedPXServiceCore.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
-	</PropertyGroup>
+        <PropertyGroup>
+                <OutputType>Library</OutputType>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        </PropertyGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\Common\Common.csproj" />


### PR DESCRIPTION
## Summary
- compile SelfHostedPXServiceCore as a library
- fix WebApp disposal
- add request/response scaffolding for OrchestrationService and use MediaTypeHeaderValue

## Testing
- `dotnet build net8/migration/SelfHostedPXServiceCore/SelfHostedPXServiceCore.csproj` *(fails: type or namespace name 'MockServiceWebRequestHandler' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6892815f74cc83299492efc7b7a10a4c