### PR TITLE
Refactor PXService test infrastructure for ASP.NET Core

### DIFF
--- a/net8/migration/COT.PXService/PXServiceClient.cs
+++ b/net8/migration/COT.PXService/PXServiceClient.cs
@@ -2,8 +2,6 @@
 
 namespace COT.PXService
 {
-    using System;
-    using Newtonsoft.Json;
     using Test.Common;
     
     public class PXServiceClient : ServiceClient
@@ -15,37 +13,5 @@ namespace COT.PXService
         {
         }
 
-        protected override string SerializeObject(object requestInput, string contentType)
-        {
-            if (contentType.ToLower().Contains("application/json"))
-            {
-                return JsonConvert.SerializeObject(requestInput);
-            }
-            else
-            {
-                throw new NotSupportedException(string.Format("{0} is not a supported content type", contentType));
-            }
-        }
-
-        protected override T Deserialize<T>(string value, string contentType)
-        {
-            if (contentType.ToLower().Contains("application/json"))
-            {
-                return JsonConvert.DeserializeObject<T>(value);
-            }
-            else if (contentType.ToLower().Contains(Constants.HeaderValues.HtmlContent))
-            {
-                return (T)Convert.ChangeType(value, typeof(T));
-            }
-            else if (string.IsNullOrEmpty(value))
-            {
-                // The response content is empty when successfully remove PI. Add this to avoid hitting the following "else".
-                return default(T);
-            }
-            else
-            {
-                throw new NotSupportedException(string.Format("{0} is not a supported content type", contentType));
-            }
-        }
     }
 }

--- a/net8/migration/SelfHostedPXServiceCore/Mocks/OrchestrationService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/Mocks/OrchestrationService.cs
@@ -7,7 +7,6 @@ namespace SelfHostedPXServiceCore.Mocks
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using System.Net.Http.Headers;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Commerce.Payments.Common.Tracing;
@@ -58,7 +57,7 @@ namespace SelfHostedPXServiceCore.Mocks
                     Content = new StringContent(
                             content: foundMatch.Content,
                             encoding: System.Text.Encoding.UTF8,
-                            mediaType: new MediaTypeHeaderValue("application/json"))
+                            mediaType: "application/json")
                 };
             }
 


### PR DESCRIPTION
## Summary
- Simplify PXServiceClient to align with updated ServiceClient API
- Fix OrchestrationService mock to expose tracking fields and correctly set JSON content type

## Testing
- `dotnet test net8/migration/COT.PXService/COT.PXService.csproj` *(fails: type or namespace name 'EventTraceActivity' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68928a0de3408329965c242388a6f0a2