### PR TITLE
Add Dockerfile and container instructions for PXService.Web

### DIFF
--- a/net8/migration/PXService.Web/Dockerfile
+++ b/net8/migration/PXService.Web/Dockerfile
@@ -1,0 +1,11 @@
+# Multi-stage build for PXService.Web
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore PXService.Web/PXService.Web.csproj
+RUN dotnet publish PXService.Web/PXService.Web.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Microsoft.Commerce.Payments.PXService.dll"]

--- a/net8/migration/PXService.Web/README.md
+++ b/net8/migration/PXService.Web/README.md
@@ -1,0 +1,19 @@
+# PXService.Web Docker
+
+Build and run the PXService Web project in a container.
+
+## Build
+
+From the `net8/migration` directory:
+
+```bash
+docker build -f PXService.Web/Dockerfile -t pxservice-web .
+```
+
+## Run
+
+```bash
+docker run -p 8080:8080 pxservice-web
+```
+
+The service listens on port 8080 inside the container.


### PR DESCRIPTION
## Summary
- add Dockerfile for PXService.Web
- document docker build/run steps

## Testing
- `dotnet restore net8/migration/PXService.Web/PXService.Web.csproj` *(fails: referenced projects not found)*
- `dotnet build net8/migration/PXService.Web/PXService.Web.csproj` *(fails: missing types)*
- `docker build -f PXService.Web/Dockerfile -t pxservice-web .` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6893cdb680f88329bf3be9bfed31f4be