### PR TITLE
Add Swagger setup to PXService.Web

### DIFF
--- a/net8/migration/PXService.Web/Program.cs
+++ b/net8/migration/PXService.Web/Program.cs
@@ -12,6 +12,9 @@ builder.Services
     .AddNewtonsoftJson(options =>
         options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore);
 
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
 var validateCors = builder.Configuration.GetValue<bool>("PXServiceSettings:ValidateCors");
 var corsOrigins = builder.Configuration.GetSection("PXServiceSettings:CorsAllowedOrigins").Get<string[]>();
 
@@ -29,6 +32,12 @@ if (validateCors)
 }
 
 var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
 
 if (!app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
## Summary
- enable swagger generation and UI for PXService.Web

## Testing
- `dotnet build net8/migration/PXService.Web/PXService.Web.csproj` *(fails: RequestContext could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6893dc9ee5388329ba9fcad296c0b71c