### PR TITLE
Define unique action routes for controller methods

### DIFF
--- a/net8/migration/PXService.Web/Controllers/AddressDescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/AddressDescriptionsController.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<List<PIDLResource>> GetById(
             string accountId,
             string country,
@@ -374,6 +375,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
+        [Route("[action]")]
         public async Task<List<PIDLResource>> GetAddressGroupsById(
             string accountId,
             string country,
@@ -408,6 +411,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
+        [Route("[action]")]
         public object GetAddressDescriptions(
             string country,
             string type,

--- a/net8/migration/PXService.Web/Controllers/AddressesController.cs
+++ b/net8/migration/PXService.Web/Controllers/AddressesController.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A validation result</response>
         /// <returns>A validation result</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> LegacyValidate([FromBody]PIDLData address, string type = null)
         {
             const string ValidAddressResponse = "Valid";
@@ -92,6 +93,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A validation result</response>
         /// <returns>A validation result</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> ModernValidate([FromBody]PIDLData address)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -143,6 +145,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A validation result</response>
         /// <returns>A validation result</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> ModernValidate(
             [FromBody] PIDLData address,
             string partner,

--- a/net8/migration/PXService.Web/Controllers/AddressesExController.cs
+++ b/net8/migration/PXService.Web/Controllers/AddressesExController.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">An address object</response>
         /// <returns>An address object</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> GetAddressById(string accountId, string addressId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -60,6 +61,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">An address object</response>
         /// <returns>An address object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> Post(
             [FromBody]PIDLData address, 
             string accountId, 
@@ -128,6 +130,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">An address object</response>
         /// <returns>An address object</returns>
         [HttpPatch]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> Patch(
             [FromBody] PIDLData address, 
             string accountId, 

--- a/net8/migration/PXService.Web/Controllers/AgenticTokenDesctipionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/AgenticTokenDesctipionsController.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]        
         [HttpGet]
+        [Route("[action]")]
         public List<PIDLResource> Get(string accountId, string country, string type, string operation, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string piid = null)
         {
             // Use Partner Settings if enabled for the partner

--- a/net8/migration/PXService.Web/Controllers/BillingGroupDescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/BillingGroupDescriptionsController.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public List<PIDLResource> GetBillingGroupsDescription(string accountId, string country, string operation = Constants.Operations.SelectInstance, string type = null, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string scenario = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.Web/Controllers/ChallengeDescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/ChallengeDescriptionsController.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Returns challenge PIDL for the given type</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<List<PIDLResource>> GetById(
             string accountId,
             string type,
@@ -107,6 +108,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Returns challenge PIDL for the given type and specfic to the given piid</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<ActionResult<List<PIDLResource>>> GetByTypePiidAndSessionId(
             string accountId,
             string piid,
@@ -177,6 +179,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Returns challenge PIDL for the given type and specfic to the given piid</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<ActionResult<List<PIDLResource>>> GetByTypeAndPiid(
             string accountId,
             string piid,
@@ -241,6 +244,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">List&lt;PIDLResource&gt;</response>
         /// <returns>Returns challenge PIDL for the given type and specfic to the given piid</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> GetPaymentChallenge(
             string accountId,
             string paymentSessionOrData,
@@ -573,6 +577,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <throws>HttpResponseException if the payment instrument cannot be found</throws>
         /// <returns>Returns a PIDL representing the next action that needs to be taken</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<ActionResult<List<PIDLResource>>> GetByPiidAndSessionId(
                 string accountId, string piid, string sessionId,
                 string partner = null, string language = null, string orderId = null)
@@ -675,6 +680,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Returns a challenge PIDL</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<ActionResult<List<PIDLResource>>> GetByAccountIdAndPiid(
             string accountId,
             string piid,

--- a/net8/migration/PXService.Web/Controllers/CheckoutDescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/CheckoutDescriptionsController.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <param name="scenario" required="false" cref="string" in="query">Scenario name</param>
         /// <returns>A list of PIDLResource</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<object> GetCheckoutDescriptions(
             string checkoutId,
             string paymentProviderId,

--- a/net8/migration/PXService.Web/Controllers/CheckoutRequestsExController.cs
+++ b/net8/migration/PXService.Web/Controllers/CheckoutRequestsExController.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         /// <response code="200">CheckoutRequest object</response>
         /// <returns>CheckoutRequest object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> AttachAddress(
             [FromBody] PIDLData address,
             string checkoutRequestId,
@@ -105,6 +106,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         /// <response code="200">CheckoutRequest object</response>
         /// <returns>CheckoutRequest object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> AttachProfile(
             [FromBody] PIDLData profile,
             string checkoutRequestId,
@@ -147,6 +149,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         /// <response code="200">CheckoutRequest object</response>
         /// <returns>CheckoutRequest object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> Confirm(
             [FromBody] PIDLData confirmPayload,
             string checkoutRequestId,
@@ -290,6 +293,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         /// <response code="200">CheckoutRequest object</response>
         /// <returns>CheckoutRequest object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> AttachPaymentInstrument(
             [FromBody] PIDLData paymentInstrument,
             string checkoutRequestId,

--- a/net8/migration/PXService.Web/Controllers/CheckoutsExController.cs
+++ b/net8/migration/PXService.Web/Controllers/CheckoutsExController.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.Checkouts
         /// <response code="200">Returns the HttpResponse to iFrame that posts message to parent window to redirect the page</response>
         /// <returns>Returns the HttpResponse to iFrame that posts message to parent window to redirect the page</returns>
         [HttpGet]
+        [Route("[action]")]
         public HttpResponseMessage Completed(
             string redirectUrl,
             string checkoutId,
@@ -95,6 +96,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.Checkouts
         /// <response code="200">Returns the pidl redirect</response>
         /// <returns>Returns the pidl redirect</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> Charge(
             string paymentProviderId,
             string checkoutId,
@@ -216,6 +218,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.Checkouts
         /// <response code="200">Returns the status pidl</response>
         /// <returns>Returns the status pidl</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> Status(
             string paymentProviderId,
             string checkoutId)

--- a/net8/migration/PXService.Web/Controllers/DescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/DescriptionsController.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Returns a PIDL for the given component</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> Get(
             string component,
             string partner = V7.Constants.TemplateName.DefaultTemplate,

--- a/net8/migration/PXService.Web/Controllers/ExpressCheckoutController.cs
+++ b/net8/migration/PXService.Web/Controllers/ExpressCheckoutController.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">ExpressCheckoutResult object</response>
         /// <returns>ExpressCheckoutResult object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<ActionResult<ExpressCheckoutResult>> Confirm(
             string accountId,
             [FromBody] PIDLData confirmPayload,

--- a/net8/migration/PXService.Web/Controllers/InitializationController.cs
+++ b/net8/migration/PXService.Web/Controllers/InitializationController.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">An Initialize object</response>
         /// <returns>A Initialize result include all payment client component props</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> Initialize(
             [FromBody] PIDLData initializeData)
         {

--- a/net8/migration/PXService.Web/Controllers/MSRewardsController.cs
+++ b/net8/migration/PXService.Web/Controllers/MSRewardsController.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">Redeem Response object</response>
         /// <returns>Redeem Response object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<PIDLResource> PostRedeemRequest(
             [FromBody] MSRewardsRedeemRequest redeemData,
             string accountId,

--- a/net8/migration/PXService.Web/Controllers/PaymentInstrumentsExController.cs
+++ b/net8/migration/PXService.Web/Controllers/PaymentInstrumentsExController.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">Html post message for anonymous resume pending operation</response>
         /// <returns>Html post message</returns>
         [HttpGet]
+        [Route("[action]")]
         public HttpResponseMessage AnonymousResumePendingOperation(
             string piid,
             bool isSuccessful = false,
@@ -127,6 +128,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A payment instrument object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> CreateModernPI(
             [FromBody] PIDLData pi,
             string sessionId = null,
@@ -187,6 +189,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A list of payment instrument</response>
         /// <returns>A list of payment instrument or IPidlPayload object</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> ListModernPIs(
             string accountId,
             string[] status = null,
@@ -327,6 +330,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A payment instrument object</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<PaymentInstrument> GetModernPI(
             string accountId,
             string piid,
@@ -537,6 +541,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A payment instrument object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> PostModernPI(
             string accountId,
             [FromBody] PIDLData pi,
@@ -581,6 +586,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A payment instrument object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> UpdateModernPI(
             string accountId,
             string piid,
@@ -748,6 +754,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A payment instrument object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> ReplaceModernPI(
             string accountId,
             string piid,
@@ -877,6 +884,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A PIDLResource object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<PIDLResource> RedeemModernPI(
             string accountId,
             string piid,
@@ -933,6 +941,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A payment instrument object</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<object> RedeemModernPI(
             string accountId,
             string piid,
@@ -983,6 +992,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A payment instrument object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> RemoveModernPI(
             string accountId,
             string piid,
@@ -1097,6 +1107,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A payment instrument object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> ResumePendingOperation(
             string accountId,
             string piid,
@@ -1341,6 +1352,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A card profeil object</response>
         /// <returns>A payment instrument object</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<object> GetCardProfile(string accountId, string piid, ulong deviceId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -1361,6 +1373,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A card profeil object</response>
         /// <returns>A payment instrument object</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<object> GetSeCardPersos(string accountId, string piid, ulong deviceId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -1382,6 +1395,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<object> PostReplenishTransactionCredentials(string accountId, string piid, ulong deviceId, [FromBody] object requestData)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -1403,6 +1417,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<object> AcquireLUKs(string accountId, string piid, ulong deviceId, [FromBody] object requestData)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -1423,6 +1438,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<object> ConfirmLUKs(string accountId, ulong deviceId, string piid)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -1444,6 +1460,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<object> ValidateCvv(string accountId, string piid, string language, [FromBody] object requestData)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -1503,6 +1520,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <param name="sessionId">Optional sessionId to be used for the apply flow. If this is not provided, initializeData is used to create a sessionId</param>
         /// <returns>Message from IssuerService API</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> Apply(
             string partner,
             string operation,
@@ -1590,6 +1608,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A list of payment instrument</response>
         /// <returns>Response message with populated ChallengeContext object</returns>
         [HttpGet]
+        [Route("[action]")]
         [ActionName("GetChallengeContext")]
         public async Task<HttpResponseMessage> GetChallengeContext(
             string accountId,

--- a/net8/migration/PXService.Web/Controllers/PaymentMethodDescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/PaymentMethodDescriptionsController.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         //// Anonymous Add or Update
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<List<PIDLResource>> GetAnonymousPidl(
             string family,
             string type = null,
@@ -245,6 +246,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         //// If the family is specified, operation must be add or update
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<List<PIDLResource>> GetByFamilyAndType(
             string accountId,
             string family,
@@ -648,6 +650,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         //// If the family is not specified, operation must be select, selectInstance, selectSingleInstance or validateInstance
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<List<PIDLResource>> SelectPaymentResource(
             string accountId,
             string country = null,
@@ -947,6 +950,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<List<PIDLResource>> GetByFamilyAndTypeWithCompletePrerequisitesOption(
             string accountId,
             string country,

--- a/net8/migration/PXService.Web/Controllers/PaymentRequestsExController.cs
+++ b/net8/migration/PXService.Web/Controllers/PaymentRequestsExController.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         /// <response code="200">PaymentRequest object</response>
         /// <returns>PaymentRequest object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> AttachChallengeData(
             [FromBody] PIDLData paymentInstrument,
             string paymentRequestId)
@@ -69,6 +70,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentClient
         /// <response code="200">PaymentRequest object</response>
         /// <returns>PaymentRequest object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> RemoveEligiblePaymentmethods(
             [FromBody] PIDLData paymentInstrument,
             string paymentRequestId)

--- a/net8/migration/PXService.Web/Controllers/PaymentSessionDescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/PaymentSessionDescriptionsController.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Returns a PaymentSession PIDL for the given PaymentSessionData</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<List<PIDLResource>> Get(string accountId, string paymentSessionData)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.Web/Controllers/PaymentSessionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/PaymentSessionsController.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <param name="accountId">Pi Account Id</param>
         /// <returns>Returns the created PaymentSession</returns>
         [HttpPost]
+        [Route("[action]")]
         [ActionName("PostPaymentSession")]
         public async Task<PaymentSession> Post(string accountId)
         {
@@ -102,6 +103,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <param name="sessionId">Session Id</param>
         /// <returns>Returns queried PaymentSession that matches the session and account id</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> GetPaymentSession(string accountId, string sessionId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -240,6 +242,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <param name="sessionId">Session Id</param>
         /// <returns>Returns payment instrument or payment instrument status used for polling</returns>
         [HttpGet]
+        [Route("[action]")]
         [ActionName("qrCodeStatus")]
         public async Task<Microsoft.Commerce.Payments.PimsModel.V4.PaymentInstrument> GetQRCodePaymentSession(string accountId, string sessionId)
         {
@@ -338,6 +341,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <param name="sessionId">Session Id</param>
         /// <returns>Returns AuthenticationResponse</returns>
         [HttpPost]
+        [Route("[action]")]
         [ActionName("Authenticate")]
         public async Task<AuthenticationResponse> Authenticate(string accountId, string sessionId)
         {
@@ -375,6 +379,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <param name="accountId">Pi Account Id</param>
         /// <returns>Returns the created PaymentSession</returns>
         [HttpPost]
+        [Route("[action]")]
         [ActionName("CreateAndAuthenticate")]
         public async Task<CreateAndAuthenticateResponse> CreateAndAuthenticate(string accountId)
         {
@@ -448,6 +453,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <param name="sessionId">Session Id</param>
         /// <returns>Returns the created PaymentSession</returns>
         [HttpPost]
+        [Route("[action]")]
         [ActionName("NotifyThreeDSChallengeCompleted")]
         public async Task<HttpResponseMessage> NotifyThreeDSChallengeCompleted(string accountId, string sessionId)
         {
@@ -470,6 +476,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <param name="sessionId">Session Id</param>
         /// <returns>Returns the created PaymentSession</returns>
         [HttpPost]
+        [Route("[action]")]
         [ActionName("BrowserAuthenticate")]
         public async Task<HttpResponseMessage> Authenticate(string sessionId)
         {
@@ -659,6 +666,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         }
 
         [HttpPost]
+
+        [Route("[action]")]
         [ActionName("BrowserNotifyThreeDSChallengeCompleted")]
         public async Task<HttpResponseMessage> NotifyThreeDSChallengeCompleted(string sessionId)
         {
@@ -753,6 +762,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <param name="cvvChallengePayload">Payload containing tokenized CVV</param>
         /// <returns>Returns RDS URL</returns>
         [HttpPost]
+        [Route("[action]")]
         [ActionName("BrowserAuthenticateThreeDSOne")]
         public async Task<HttpResponseMessage> BrowserAuthenticateThreeDSOne(
             string accountId,
@@ -950,6 +960,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <param name="rx">Payload containing tokenized CVV</param>
         /// <returns>Returns the HTML that does a POST to ACS Url</returns>
         [HttpGet]
+        [Route("[action]")]
         [ActionName("BrowserAuthenticateRedirectionThreeDSOne")]
         public async Task<HttpResponseMessage> BrowserAuthenticateRedirectionThreeDSOne(string sessionId, string ru, string rx)
         {
@@ -985,6 +996,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         }
 
         [HttpPost]
+
+        [Route("[action]")]
         [ActionName("BrowserNotifyThreeDSOneChallengeCompleted")]
         public async Task<HttpResponseMessage> BrowserNotifyThreeDSOneChallengeCompleted(string sessionId)
         {
@@ -1048,6 +1061,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <param name="cvvChallengePayload">Payload containing tokenized CVV</param>
         /// <returns>Returns RDS URL</returns>
         [HttpPost]
+        [Route("[action]")]
         [ActionName("AuthenticateIndiaThreeDS")]
         public async Task<HttpResponseMessage> AuthenticateIndiaThreeDS(string accountId, string sessionId, [FromBody] PIDLData cvvChallengePayload)
         {
@@ -1145,6 +1159,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns an object with the property Verified=true when the challenge has been verified or is not applicable.
         /// False if the challenge was failed or its status is unknown.</returns>
         [HttpGet]
+        [Route("[action]")]
         [ActionName("AuthenticationStatus")]
         public async Task<HttpResponseMessage> AuthenticationStatus(string accountId, string sessionId, string piId, string paymentContext = null)
         {

--- a/net8/migration/PXService.Web/Controllers/PaymentTransactionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/PaymentTransactionsController.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentTransaction
         /// indicating if the associated PI should be blocked from deletion (e.g. a hardware order which has not yet
         /// shipped and hence funds have been authorized but not captured yet.)</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<PaymentTransactions> ListTransactions(
             string accountId,
             string continuationToken = null,
@@ -114,6 +115,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentTransaction
         /// indicating if the associated PI should be blocked from deletion (e.g. a hardware order which has not yet
         /// shipped and hence funds have been authorized but not captured yet.)</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> ListTransactions(string accountId, string country, string language, string partner, [FromBody] PIDLData requestData)
         {
             // NOTE Add traces and logs

--- a/net8/migration/PXService.Web/Controllers/PidlTransformationController.cs
+++ b/net8/migration/PXService.Web/Controllers/PidlTransformationController.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A PidlTransformationResult object</response>
         /// <returns>A PidlTransformationResult object</returns>
         [HttpPost]
+        [Route("[action]")]
         public PidlTransformationResult<string> Post([FromBody] PidlTransformationParameter transformationParameter)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.Web/Controllers/PidlValidationController.cs
+++ b/net8/migration/PXService.Web/Controllers/PidlValidationController.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A payment instrument object</response>
         /// <returns>A PidlExecutionResult object</returns>
         [HttpPost]
+        [Route("[action]")]
         public PidlExecutionResult Post([FromBody] PidlValidationParameter validationParameter, string language = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.Web/Controllers/ProbeController.cs
+++ b/net8/migration/PXService.Web/Controllers/ProbeController.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Commerce.Payments.PXService.Controllers
         /// </summary>
         /// <returns>Probe status</returns>
         [HttpGet]
+        [Route("[action]")]
         public ActionResult<ServiceStatus> Get()
         {
             string buildVersion = this.configuration[BuildVersionKey] ?? "unknown";

--- a/net8/migration/PXService.Web/Controllers/ProfileDescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/ProfileDescriptionsController.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<List<PIDLResource>> GetByCountry(string accountId, string country, string type, string operation = Constants.Operations.Add, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string scenario = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.Web/Controllers/RDSSessionController.cs
+++ b/net8/migration/PXService.Web/Controllers/RDSSessionController.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A rds Status Pidl</response>
         /// <returns>A rds Status Pidl</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> Query([FromBody]PIDLData sessionDetails, string sessionId = null, string piid = null, string partner = null, string language = null, string country = null, string scenario = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.Web/Controllers/RewardsDescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/RewardsDescriptionsController.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>Returns a rewards PIDL for the given rewardscontext</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<List<PIDLResource>> Get(
             string accountId,
             string type,

--- a/net8/migration/PXService.Web/Controllers/SessionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/SessionsController.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A session object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public async Task<SecondScreenSessionData> GetBySessionId(string sessionId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -59,6 +60,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A session object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpPost]
+        [Route("[action]")]
         public string PostBySessionId(string sessionId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -76,6 +78,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">The created session resource</response>
         /// <returns>The created session resource</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<SessionResponse> PostSession([FromBody]SessionRequest sessionTokenInfo)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.Web/Controllers/SettingsController.cs
+++ b/net8/migration/PXService.Web/Controllers/SettingsController.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A setting object</response>
         /// <returns>A setting object</returns>
         [HttpGet]
+        [Route("[action]")]
         public ActionResult GetSettings(string appName, string appVersion, string language = null)
         {
             if (string.Equals(appName, Constants.AppDetails.WalletPackageName, StringComparison.OrdinalIgnoreCase))
@@ -83,6 +84,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A setting object</response>
         /// <returns>A setting object</returns>
         [HttpPost]
+        [Route("[action]")]
         public ServerSettingResponse GetSettingsInPost(string accountId, [FromBody] ClientConfigData clientConfigData)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.Web/Controllers/TaxIdDescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/TaxIdDescriptionsController.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public List<PIDLResource> Get(string accountId, string country, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string type = null)
         {
             // Use Partner Settings if enabled for the partner
@@ -59,6 +60,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public List<PIDLResource> GetStandaloneTaxPidl(string accountId, string country, string operation, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string type = null, string scenario = null)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -274,6 +276,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public List<PIDLResource> GetStandaloneTaxPidl(string country, string operation, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName, string type = null, string scenario = null)
         {
             return this.GetStandaloneTaxPidl(

--- a/net8/migration/PXService.Web/Controllers/TenantDescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/TenantDescriptionsController.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
+        [Route("[action]")]
         public List<PIDLResource> Get(string accountId, string type, string country, string language = null, string partner = Constants.ServiceDefaults.DefaultPartnerName)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.Web/Controllers/TokensExController.cs
+++ b/net8/migration/PXService.Web/Controllers/TokensExController.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A list of PIDLResource</response>
         /// <returns>A list of PIDLResource object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> Tokens([FromBody] PIDLData payload, string accountId, string partner, string piid, string country, string language)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -138,6 +139,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> PostChallenge([FromBody] PIDLData payload, string accountId, string ntid, string challengeId, string country, string language, string partner)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -191,6 +193,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> ValidateChallenge([FromBody] PIDLData payload, string accountId, string ntid, string challengeId, string country, string language, string partner, string challengeMethodId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -243,6 +246,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> Mandates([FromBody] PIDLData payload, string accountId, string ntid)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();

--- a/net8/migration/PXService.Web/Controllers/WalletsController.cs
+++ b/net8/migration/PXService.Web/Controllers/WalletsController.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">A json configuration</response>
         /// <returns>Json configuration</returns>
         [HttpGet]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> GetWalletConfig(
             string partner = null,
             string client = null)
@@ -98,6 +99,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">Returns the wallet session object</response>
         /// <returns>Returns wallet session object</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<string> SetupWalletProviderSession(
             [FromBody] SetupProviderSessionIncomingPayload payload)
         {
@@ -119,6 +121,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <response code="200">Returns the session id</response>
         /// <returns>Returns session id</returns>
         [HttpPost]
+        [Route("[action]")]
         public async Task<HttpResponseMessage> ProvisionWalletToken(
             string accountId,
             [FromBody] ProvisionWalletTokenIncomingPayload payload)


### PR DESCRIPTION
## Summary
- add `[Route("[action]")]` attribute to controller actions so each HTTP verb has a unique path

## Testing
- `dotnet build openedx/net8/migration/PXService.Web/PXService.Web.csproj` *(fails: missing assemblies, 958 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689466282e748329a7cfa64002a01065