### PR TITLE
fix: remove duplicate route attributes in AddressDescriptionsController

### DIFF
--- a/net8/migration/PXService.Web/Controllers/AddressDescriptionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/AddressDescriptionsController.cs
@@ -376,7 +376,6 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
         [Route("[action]")]
-        [Route("[action]")]
         public async Task<List<PIDLResource>> GetAddressGroupsById(
             string accountId,
             string country,
@@ -411,7 +410,6 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A list of PIDLResource object</returns>
         [SuppressMessage("Microsoft.Performance", "CA1822", Justification = "Needs to be an instance method for Route action selection")]
         [HttpGet]
-        [Route("[action]")]
         [Route("[action]")]
         public object GetAddressDescriptions(
             string country,


### PR DESCRIPTION
## Summary
- fix Swagger conflicts for AddressDescriptions by removing duplicate `[Route]` attributes

## Testing
- `dotnet build` *(fails: PaymentTransactions namespace not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894729d139c8329bc4d3d771ce98471