### PR TITLE
fix: resolve Swagger route conflicts in PXService controllers

### DIFF
--- a/net8/migration/PXService.Web/Controllers/AddressesController.cs
+++ b/net8/migration/PXService.Web/Controllers/AddressesController.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         }
 
         /// <summary>
-        /// Modern Validate address ("/ModernValidateByType" is not in the real path, just as a workaround to show multiple APIs with the same path and http verb but with different params in open API doc)
+        /// Modern Validate address by type.
         /// </summary>
         /// <group>Addresses</group>
         /// <verb>POST</verb>
@@ -146,7 +146,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         /// <returns>A validation result</returns>
         [HttpPost]
         [Route("[action]")]
-        public async Task<HttpResponseMessage> ModernValidate(
+        public async Task<HttpResponseMessage> ModernValidateByType(
             [FromBody] PIDLData address,
             string partner,
             string language,

--- a/net8/migration/PXService.Web/Controllers/PaymentSessionsController.cs
+++ b/net8/migration/PXService.Web/Controllers/PaymentSessionsController.cs
@@ -342,7 +342,6 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns AuthenticationResponse</returns>
         [HttpPost]
         [Route("[action]")]
-        [ActionName("Authenticate")]
         public async Task<AuthenticationResponse> Authenticate(string accountId, string sessionId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -454,7 +453,6 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns the created PaymentSession</returns>
         [HttpPost]
         [Route("[action]")]
-        [ActionName("NotifyThreeDSChallengeCompleted")]
         public async Task<HttpResponseMessage> NotifyThreeDSChallengeCompleted(string accountId, string sessionId)
         {
             EventTraceActivity traceActivityId = this.Request.GetRequestCorrelationId();
@@ -477,8 +475,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         /// <returns>Returns the created PaymentSession</returns>
         [HttpPost]
         [Route("[action]")]
-        [ActionName("BrowserAuthenticate")]
-        public async Task<HttpResponseMessage> Authenticate(string sessionId)
+        public async Task<HttpResponseMessage> BrowserAuthenticate(string sessionId)
         {
             ClientAction nextAction = null;
             try
@@ -666,10 +663,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
         }
 
         [HttpPost]
-
         [Route("[action]")]
-        [ActionName("BrowserNotifyThreeDSChallengeCompleted")]
-        public async Task<HttpResponseMessage> NotifyThreeDSChallengeCompleted(string sessionId)
+        public async Task<HttpResponseMessage> BrowserNotifyThreeDSChallengeCompleted(string sessionId)
         {
             ClientAction clientAction = null;
             try


### PR DESCRIPTION
## Summary
- rename duplicate ModernValidate endpoint to ModernValidateByType
- rename browser-specific payment session actions for unique Swagger routes

## Testing
- `dotnet build` *(fails: SearchTransactionAccountinfoByPI not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894789b58d88329afc799e075b510b1