### PR TITLE
chore: clean PXService warnings for .NET 8

### DIFF
--- a/net8/migration/PXService/Model/ChallengeManagementService/ChallengeCreationModel.cs
+++ b/net8/migration/PXService/Model/ChallengeManagementService/ChallengeCreationModel.cs
@@ -2,11 +2,7 @@
 
 namespace Microsoft.Commerce.Payments.PXService.Model.ChallengeManagementService
 {
-    using System;
-    using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
-    using System.Linq;
-    using System.Web;
     using Newtonsoft.Json;
     using static Microsoft.Commerce.Payments.PXService.Model.ChallengeManagementService.ChallengeEnumDefinition;
 

--- a/net8/migration/PXService/Model/ChallengeManagementService/ChallengeEnumDefinition.cs
+++ b/net8/migration/PXService/Model/ChallengeManagementService/ChallengeEnumDefinition.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Commerce.Payments.PXService.Model.ChallengeManagementService
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Linq;
-    using System.Web;
 
     public class ChallengeEnumDefinition
     {

--- a/net8/migration/PXService/Model/ChallengeManagementService/ChallengeStatusResult.cs
+++ b/net8/migration/PXService/Model/ChallengeManagementService/ChallengeStatusResult.cs
@@ -2,10 +2,6 @@
 
 namespace Microsoft.Commerce.Payments.PXService.Model.ChallengeManagementService
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Web;
     using Newtonsoft.Json;
 
     public class ChallengeStatusResult

--- a/net8/migration/PXService/Model/ChallengeManagementService/SessionDataModel.cs
+++ b/net8/migration/PXService/Model/ChallengeManagementService/SessionDataModel.cs
@@ -2,10 +2,6 @@
 
 namespace Microsoft.Commerce.Payments.PXService.Model.ChallengeManagementService
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Web;
     using Newtonsoft.Json;
 
     public class SessionDataModel

--- a/net8/migration/PXService/Model/ChallengeManagementService/SessionEnumDefinition.cs
+++ b/net8/migration/PXService/Model/ChallengeManagementService/SessionEnumDefinition.cs
@@ -2,11 +2,7 @@
 
 namespace Microsoft.Commerce.Payments.PXService.Model.ChallengeManagementService
 {
-    using System;
-    using System.Collections.Generic;
     using System.ComponentModel;
-    using System.Linq;
-    using System.Web;
 
     public class SessionEnumDefinition
     {

--- a/net8/migration/PXService/PXService.csproj
+++ b/net8/migration/PXService/PXService.csproj
@@ -14,30 +14,25 @@
 		<PackageReference Include="CoreWCF.Primitives" />
 		<PackageReference Include="CoreWCF.Http" />
 		<PackageReference Include="CoreWCF.ConfigurationManager" />
-		<PackageReference Include="Swashbuckle.AspNetCore" />
-		<PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters.CoreServices" />
-		<PackageReference Include="System.ServiceModel.Http" />
-		<PackageReference Include="System.ServiceModel.Primitives" />
-		<PackageReference Include="Yarp.ReverseProxy" />
-		<PackageReference Include="Swashbuckle.AspNetCore" />
-		<PackageReference Include="Microsoft.Identity.Web" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
-		<PackageReference Include="Microsoft.Commerce.Payments.Authentication" />
+                <PackageReference Include="Swashbuckle.AspNetCore" />
+                <PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters.CoreServices" />
+                <PackageReference Include="System.ServiceModel.Http" />
+                <PackageReference Include="System.ServiceModel.Primitives" />
+                <PackageReference Include="Yarp.ReverseProxy" />
+                <PackageReference Include="Microsoft.Identity.Web" />
+                <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
+                <PackageReference Include="Microsoft.Commerce.Payments.Authentication" />
 		<PackageReference Include="Azure.Analytics.Experimentation.AspNetCore" />
 		<PackageReference Include="Azure.Analytics.Experimentation.VariantAssignment" />
 		<PackageReference Include="Azure.Analytics.Experimentation.VariantAssignment.Client" />
-		<PackageReference Include="Azure.Analytics.Experimentation.VariantAssignment.Contract" />
-		<PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters.CoreServices" />
-		<PackageReference Include="Azure.Identity" />
-		<PackageReference Include="Microsoft.Commerce.Payments.Management.CertificateVerificationCore" />
-		<PackageReference Include="Microsoft.Identity.Web" />
-		<PackageReference Include="OpenTelemetry" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
-		<PackageReference Include="Newtonsoft.Json" />
-		<PackageReference Include="Microsoft.Commerce.Payments.Authentication" />
-		<PackageReference Include="Azure.Storage.Blobs" />
-		<PackageReference Include="UAParser" />
+                <PackageReference Include="Azure.Analytics.Experimentation.VariantAssignment.Contract" />
+                <PackageReference Include="Azure.Identity" />
+                <PackageReference Include="Microsoft.Commerce.Payments.Management.CertificateVerificationCore" />
+                <PackageReference Include="OpenTelemetry" />
+                <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+                <PackageReference Include="Newtonsoft.Json" />
+                <PackageReference Include="Azure.Storage.Blobs" />
+                <PackageReference Include="UAParser" />
 	</ItemGroup>
 
 	<!-- Bring along the WCF configuration file at build time -->

--- a/net8/migration/PXService/Program.cs
+++ b/net8/migration/PXService/Program.cs
@@ -1,11 +1,9 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Commerce.Payments.PXCommon;
-using Microsoft.Commerce.Payments.PXService;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
-using System.Web.Services.Description;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services

--- a/net8/migration/PXService/V7/ClientActionFactory.cs
+++ b/net8/migration/PXService/V7/ClientActionFactory.cs
@@ -4,8 +4,6 @@ namespace Microsoft.Commerce.Payments.PXService.V7
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Web;
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.PartnerSettingsModel;
     using Microsoft.Commerce.Payments.PidlFactory.V7;

--- a/net8/migration/PXService/V7/Model/CheckoutStatusResponse.cs
+++ b/net8/migration/PXService/V7/Model/CheckoutStatusResponse.cs
@@ -1,10 +1,6 @@
 ﻿// <copyright file="CheckoutStatusResponse.cs" company="Microsoft">Copyright (c) Microsoft. All rights reserved.</copyright>
 
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
 
 namespace Microsoft.Commerce.Payments.PXService.V7
 {

--- a/net8/migration/PXService/V7/PaymentChallenge/PaymentSessionDescriptionsController.cs
+++ b/net8/migration/PXService/V7/PaymentChallenge/PaymentSessionDescriptionsController.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using System.Web.Http;
 
     public class PaymentSessionDescriptionsController : ProxyController
     {

--- a/net8/migration/PXService/V7/PaymentTransaction/Model/ClientContext.cs
+++ b/net8/migration/PXService/V7/PaymentTransaction/Model/ClientContext.cs
@@ -2,10 +2,6 @@
 
 namespace Microsoft.Commerce.Payments.PXService.V7.PaymentTransaction.Model
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Web;
     using Newtonsoft.Json;
 
     public class ClientContext


### PR DESCRIPTION
## Summary
- remove duplicate package references
- drop obsolete System.Web usings

## Testing
- `dotnet build` *(fails: Unable to find package Microsoft.Commerce.Payments.Authentication)*

------
https://chatgpt.com/codex/tasks/task_e_689b7b728b348329a4ca0c273a37299e