### PR TITLE
Remove HttpRequestMessage.Properties usage and address null warnings

### DIFF
--- a/net8/migration/PXService/ClientActionFilter.cs
+++ b/net8/migration/PXService/ClientActionFilter.cs
@@ -91,13 +91,13 @@ namespace Microsoft.Commerce.Payments.PXService
             Digitization,
         }
 
-        public string PendingOn { get; private set; }
+        public string? PendingOn { get; private set; }
 
         public bool PendingOnContainedIn { get; private set; }
 
-        public string RequestType { get; private set; }
+        public string? RequestType { get; private set; }
 
-        public string Partner { get; private set; }
+        public string? Partner { get; private set; }
 
         public bool PartnerContainedIn { get; private set; }
 
@@ -146,7 +146,7 @@ namespace Microsoft.Commerce.Payments.PXService
 
         public void UpdateClientAction(ResourceLifecycleStateManager.ClientActionResourceState state)
         {
-            ClientAction clientAction = null;
+            ClientAction? clientAction = null;
 
             switch (this.ClientActionType)
             {
@@ -211,7 +211,7 @@ namespace Microsoft.Commerce.Payments.PXService
                         {
                             if (this.ClearMembers)
                             {
-                                List<PIDLResource> redirectPidl = null;
+                                List<PIDLResource>? redirectPidl = null;
 
                                 if (this.IsStaticRedirect)
                                 {

--- a/net8/migration/PXService/ConfigurationComponentRule.cs
+++ b/net8/migration/PXService/ConfigurationComponentRule.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Commerce.Payments.PXService
     {
         private static readonly Func<string[], int, bool> SingleRowPredicate = (row, i) => false;
 
-        public ConfigurationComponentRule(Func<string[], int, bool> isRowInRange = null, Func<string[], bool> isRowInList = null, Dictionary<string, ConfigurationComponentRule> subComponentRules = null)
+        public ConfigurationComponentRule(Func<string[], int, bool>? isRowInRange = null, Func<string[], bool>? isRowInList = null, Dictionary<string, ConfigurationComponentRule>? subComponentRules = null)
         {
             this.IsRowInRange = isRowInRange ?? ConfigurationComponentRule.SingleRowPredicate;
             this.IsRowInList = isRowInList;
@@ -19,7 +19,7 @@ namespace Microsoft.Commerce.Payments.PXService
         // Function parameters: next row, relative current row index (0-based) 
         public Func<string[], int, bool> IsRowInRange { get; }
 
-        public Func<string[], bool> IsRowInList { get; }
+        public Func<string[], bool>? IsRowInList { get; }
 
         public bool IsList
         {

--- a/net8/migration/PXService/ContextHelper.cs
+++ b/net8/migration/PXService/ContextHelper.cs
@@ -26,14 +26,14 @@ namespace Microsoft.Commerce.Payments.PXService
         /// <returns>Returns the context value or null if not found.</returns>
         public static string TryGetContextValue(Dictionary<string, object> context, string contextPath)
         {
-            string retVal = null;
+            string? retVal = null;
             string[] contextKeys = contextPath.Split(new char[] { '.' });
             if (contextKeys.Length != 2)
             {
                 throw new ArgumentException("Currently, only 2 levels are supported in the context dictionary");
             }
 
-            Dictionary<string, string> contextGroup;
+            Dictionary<string, string>? contextGroup;
             if (context.ContainsKey(contextKeys[0]))
             {
                 contextGroup = context[contextKeys[0]] as Dictionary<string, string>;
@@ -83,7 +83,7 @@ namespace Microsoft.Commerce.Payments.PXService
             }
 
             bool isEncoded = false;
-            IEnumerable<string> encoding = null;
+            IEnumerable<string>? encoding = null;
             if (request.Headers.TryGetValues(GlobalConstants.HeaderValues.ClientContextEncoding, out encoding))
             {
                 string clientContextEncoding = encoding.FirstOrDefault();
@@ -95,8 +95,8 @@ namespace Microsoft.Commerce.Payments.PXService
 
             foreach (string headerName in GlobalConstants.ClientContextGroups.FromHeader.Keys)
             {
-                string headerValue = null;
-                IEnumerable<string> headerValues = null;
+                string? headerValue = null;
+                IEnumerable<string>? headerValues = null;
                 if (request.Headers.TryGetValues(headerName, out headerValues))
                 {
                     headerValue = headerValues.FirstOrDefault();
@@ -108,8 +108,8 @@ namespace Microsoft.Commerce.Payments.PXService
                 }
 
                 string groupName = GlobalConstants.ClientContextGroups.FromHeader[headerName];
-                Dictionary<string, string> contextGroup = null;
-                object result = null;
+                Dictionary<string, string>? contextGroup = null;
+                object? result = null;
                 context.TryGetValue(groupName, out result);
                 contextGroup = result as Dictionary<string, string>;
                 if (contextGroup == null)
@@ -153,7 +153,7 @@ namespace Microsoft.Commerce.Payments.PXService
             }
 
             Dictionary<string, string> contextGroup;
-            object value = null;
+            object? value = null;
             if (context.TryGetValue(PidlFactory.GlobalConstants.ServiceContextGroups.Pifd, out value))
             {
                 contextGroup = value as Dictionary<string, string>;

--- a/net8/migration/PXService/ErrorDetailsFilter.cs
+++ b/net8/migration/PXService/ErrorDetailsFilter.cs
@@ -63,8 +63,8 @@ namespace Microsoft.Commerce.Payments.PXService
                 });
             }
 
-            PXCommon.ClientAction clientAction = null;
-            PimsModel.V4.PaymentInstrument reacquiredPi = null;
+            PXCommon.ClientAction? clientAction = null;
+            PimsModel.V4.PaymentInstrument? reacquiredPi = null;
 
             switch (error.ClientAction)
             {

--- a/net8/migration/PXService/HttpRequestHelper.cs
+++ b/net8/migration/PXService/HttpRequestHelper.cs
@@ -339,9 +339,9 @@ namespace Microsoft.Commerce.Payments.PXService
             return testContext;
         }
 
-        public static TestContext GetTestHeader(HttpRequestMessage incomingRequest = null)
+        public static TestContext? GetTestHeader(HttpRequestMessage? incomingRequest = null)
         {
-            TestContext testContext = null;
+            TestContext? testContext = null;
             string value = GetRequestHeader(PaymentConstants.PaymentExtendedHttpHeaders.TestHeader);
             if (value != null)
             {
@@ -486,9 +486,9 @@ namespace Microsoft.Commerce.Payments.PXService
             return Has3dsTestScenario(testContext, "px-service-3ds1-show-iframe");
         }
 
-        public static RequestContext GetRequestContext(HttpRequestMessage request, EventTraceActivity traceActivityId)
+        public static RequestContext? GetRequestContext(HttpRequestMessage request, EventTraceActivity traceActivityId)
         {
-            RequestContext requestContext = null;
+            RequestContext? requestContext = null;
             var requestContextHeader = GetRequestHeader(GlobalConstants.HeaderValues.XMsRequestContext, request) ?? GetRequestHeader(GlobalConstants.HeaderValues.RequestContext, request);
             if (requestContextHeader != null)
             {

--- a/net8/migration/PXService/HttpRequestMessageOptionsExtensions.cs
+++ b/net8/migration/PXService/HttpRequestMessageOptionsExtensions.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace System.Net.Http
+{
+    public static class HttpRequestMessageOptionsExtensions
+    {
+        private static readonly HttpRequestOptionsKey<IDictionary<string, object?>> PropertiesKey = new("_Properties");
+
+        private static IDictionary<string, object?> GetPropertyBag(this HttpRequestMessage request)
+        {
+            if (!request.Options.TryGetValue(PropertiesKey, out var bag))
+            {
+                bag = new Dictionary<string, object?>();
+                request.Options.Set(PropertiesKey, bag);
+            }
+            return bag;
+        }
+
+        public static void SetProperty(this HttpRequestMessage request, string key, object? value)
+        {
+            request.GetPropertyBag()[key] = value;
+        }
+
+        public static void AddProperty(this HttpRequestMessage request, string key, object? value)
+        {
+            request.GetPropertyBag().Add(key, value);
+        }
+
+        public static bool ContainsProperty(this HttpRequestMessage request, string key)
+        {
+            return request.GetPropertyBag().ContainsKey(key);
+        }
+
+        public static T? GetProperty<T>(this HttpRequestMessage request, string key)
+        {
+            var bag = request.GetPropertyBag();
+            return bag.TryGetValue(key, out var value) ? (T?)value : default;
+        }
+
+        public static bool TryGetProperty<T>(this HttpRequestMessage request, string key, out T? value)
+        {
+            var bag = request.GetPropertyBag();
+            if (bag.TryGetValue(key, out var obj) && obj is T t)
+            {
+                value = t;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+    }
+}

--- a/net8/migration/PXService/PXServiceApiVersionHandler.cs
+++ b/net8/migration/PXService/PXServiceApiVersionHandler.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Commerce.Payments.PXService.Handlers
             flightContext.Add(Flighting.ContextKeys.BrowserVer, browserVer);
             flightContext.Add(Flighting.ContextKeys.ReferrerDomain, referrerDomain);
 
-            request.Properties[GlobalConstants.RequestPropertyKeys.FlightContext] = flightContext;
+            request.SetProperty(GlobalConstants.RequestPropertyKeys.FlightContext, flightContext);
 
             // Get feature config from AzureExp
             // TODO: if AzureExp is supporeted and needed in Sovereign clouds, then we shall enable AzureExp
@@ -1016,10 +1016,10 @@ namespace Microsoft.Commerce.Payments.PXService.Handlers
             // Use Partner Setttings Service if flight is enabled
             PartnerSettings partnerSettings = await PartnerSettingsHelper.GetPaymentExperienceSetting(settings, partner, partnerSettingsVersion, traceActivityId, exposableFeatures);
 
-            request.Properties[GlobalConstants.RequestPropertyKeys.PartnerSettings] = partnerSettings;
-            request.Properties[GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] = exposableFeatures;
-            request.Properties[GlobalConstants.RequestPropertyKeys.FlightAssignmentContext] = featureConfig?.AssignmentContext;
-            request.Properties[GlobalConstants.RequestPropertyKeys.FlightFeatureConfig] = featureConfig;
+            request.SetProperty(GlobalConstants.RequestPropertyKeys.PartnerSettings, partnerSettings);
+            request.SetProperty(GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures, exposableFeatures);
+            request.SetProperty(GlobalConstants.RequestPropertyKeys.FlightAssignmentContext, featureConfig?.AssignmentContext);
+            request.SetProperty(GlobalConstants.RequestPropertyKeys.FlightFeatureConfig, featureConfig);
 
             // When an account has the PXRateLimitPerAccountOnChallengeApis, return BadRequest response.
             // This is different from PXReturn502ForMaliciousRequest as that flight is to prevent sdk retires
@@ -1045,10 +1045,10 @@ namespace Microsoft.Commerce.Payments.PXService.Handlers
                 return responseMessage;
             }
 
-            IEnumerable<KeyValuePair<string, string>> queryStrings = null;
-            if (request.Properties.ContainsKey(PaymentConstants.Web.Properties.QueryParameters))
+            IEnumerable<KeyValuePair<string, string>>? queryStrings = null;
+            if (request.ContainsProperty(PaymentConstants.Web.Properties.QueryParameters))
             {
-                queryStrings = request.Properties[PaymentConstants.Web.Properties.QueryParameters] as IEnumerable<KeyValuePair<string, string>>;
+                queryStrings = request.GetProperty<IEnumerable<KeyValuePair<string, string>>>(PaymentConstants.Web.Properties.QueryParameters);
             }
 
             if (queryStrings == null)
@@ -1056,7 +1056,7 @@ namespace Microsoft.Commerce.Payments.PXService.Handlers
                 queryStrings = request.GetQueryNameValuePairs();
                 if (queryStrings != null)
                 {
-                    request.Properties.Add(new KeyValuePair<string, object>(PaymentConstants.Web.Properties.QueryParameters, queryStrings));
+                    request.AddProperty(PaymentConstants.Web.Properties.QueryParameters, queryStrings);
                 }
             }
 
@@ -1071,13 +1071,13 @@ namespace Microsoft.Commerce.Payments.PXService.Handlers
                 return request.CreateInvalidApiVersionResponse(externalVersion);
             }
 
-            if (request.Properties.ContainsKey(PaymentConstants.Web.Properties.Version))
+            if (request.ContainsProperty(PaymentConstants.Web.Properties.Version))
             {
-                request.Properties[PaymentConstants.Web.Properties.Version] = apiVersion;
+                request.SetProperty(PaymentConstants.Web.Properties.Version, apiVersion);
             }
             else
             {
-                request.Properties.Add(PaymentConstants.Web.Properties.Version, apiVersion);
+                request.AddProperty(PaymentConstants.Web.Properties.Version, apiVersion);
             }
 
             HttpResponseMessage response = await base.SendAsync(request, cancellationToken);

--- a/net8/migration/PXService/PXServiceInputValidationHandler.cs
+++ b/net8/migration/PXService/PXServiceInputValidationHandler.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Commerce.Payments.PXService.Handlers
                                     }
                                     else
                                     {
-                                        request.Properties["InputValidationFailed"] = true;
+                                        request.SetProperty("InputValidationFailed", true);
                                         TraceIntegrationError(request, message);
                                     }
                                 }
@@ -93,7 +93,7 @@ namespace Microsoft.Commerce.Payments.PXService.Handlers
                         }
                         else
                         {
-                            request.Properties["InputValidationFailed"] = true;
+                            request.SetProperty("InputValidationFailed", true);
                             string message = string.Format("The parameter {0} or value {1} is null or invalid in the request URL: {2}.", queryParam.Key, queryParam.Value, request.RequestUri.AbsoluteUri);
                             TraceIntegrationError(request, message);
                         }
@@ -111,9 +111,9 @@ namespace Microsoft.Commerce.Payments.PXService.Handlers
 
         private static bool IsFeatureEnabled(HttpRequestMessage request, string featureName)
         {
-            List<string> exposedFeatureFlight = new List<string>();
-            return request.Properties.TryGetValue(GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures, out exposedFeatureFlight)
-                && exposedFeatureFlight.Contains(featureName);
+            List<string>? exposedFeatureFlight = new List<string>();
+            return request.TryGetProperty(GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures, out exposedFeatureFlight)
+                && exposedFeatureFlight != null && exposedFeatureFlight.Contains(featureName);
         }
     }
 }

--- a/net8/migration/PXService/Telemetry/ApplicationInsightsProvider.cs
+++ b/net8/migration/PXService/Telemetry/ApplicationInsightsProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Commerce.Payments.PXCommon
     {
         private static readonly object syncRoot = new object();
 
-        private static TelemetryClient instance = null;
+        private static TelemetryClient? instance;
 
         internal static TelemetryClient Instance
         {
@@ -65,7 +65,7 @@ namespace Microsoft.Commerce.Payments.PXCommon
             string operationName,
             string serviceName,
             HttpRequestMessage request,
-            HttpResponseMessage response,
+            HttpResponseMessage? response,
             string requestPayload,
             string responsePayload,
             string startTime,
@@ -98,15 +98,15 @@ namespace Microsoft.Commerce.Payments.PXCommon
             string paymentMethodType,
             string country,
             HttpRequestMessage request,
-            HttpResponseMessage response,
+            HttpResponseMessage? response,
             string requestPayload,
             string responsePayload,
             string startTime,
             string requestTraceId,
-            string serverTraceId = null,
-            string message = null,
-            string errorCode = null,
-            string errorMessage = null)
+            string? serverTraceId = null,
+            string? message = null,
+            string? errorCode = null,
+            string? errorMessage = null)
         {
             var properties = new Dictionary<string, string>
             {

--- a/net8/migration/PXService/V7/GuestAccountHelper.cs
+++ b/net8/migration/PXService/V7/GuestAccountHelper.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Commerce.Payments.PXService.V7
         {
             try
             {
-                string customerType;
-                if (request.Properties.ContainsKey(CustomerTypeKey))
+                string? customerType;
+                if (request.ContainsProperty(CustomerTypeKey))
                 {
-                    customerType = request.GetProperty(CustomerTypeKey) as string;
+                    customerType = request.GetProperty<string>(CustomerTypeKey);
                 }
                 else
                 {
@@ -40,7 +40,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
                     if (!string.IsNullOrWhiteSpace(customerType))
                     {
                         // Store customer type in request properties so that it can be used without parsing customer header again.
-                        request.Properties[CustomerTypeKey] = customerType;
+                        request.SetProperty(CustomerTypeKey, customerType);
                     }
                 }
 

--- a/net8/migration/PXService/V7/PaymentClient/ComponentDescriptions/ComponentDescription.cs
+++ b/net8/migration/PXService/V7/PaymentClient/ComponentDescriptions/ComponentDescription.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Commerce.Payments.PXService
 
         public EventTraceActivity TraceActivityId { get; set; }
 
-        public HttpRequestMessage Request { get; set; }
+        public HttpRequestMessage? Request { get; set; }
 
         public IList<PimsModel.V4.PaymentInstrument> ActivePaymentInstruments
         {
@@ -246,7 +246,7 @@ namespace Microsoft.Commerce.Payments.PXService
             string country = null,
             string language = null,
             string currency = null,
-            HttpRequestMessage request = null,
+            HttpRequestMessage? request = null,
             string piid = null)
         {
             this.Operation = operation;
@@ -314,9 +314,9 @@ namespace Microsoft.Commerce.Payments.PXService
             string country = null,
             string language = null,
             string currency = null,
-            HttpRequestMessage request = null,
-            CheckoutRequestClientActions checkoutRequestClientActions = null,
-            PaymentRequestClientActions paymentRequestClientActions = null)
+            HttpRequestMessage? request = null,
+            CheckoutRequestClientActions? checkoutRequestClientActions = null,
+            PaymentRequestClientActions? paymentRequestClientActions = null)
         {
             this.Operation = operation;
             this.Partner = partner;

--- a/net8/migration/PXService/V7/PaymentClient/ComponentDescriptions/PaymentRequestConfirmDescription.cs
+++ b/net8/migration/PXService/V7/PaymentClient/ComponentDescriptions/PaymentRequestConfirmDescription.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Commerce.Payments.PXService
             string country = null,
             string language = null,
             string currency = null,
-            HttpRequestMessage request = null,
+            HttpRequestMessage? request = null,
             string piid = null)
         {
             this.Operation = operation;


### PR DESCRIPTION
## Summary
- replace deprecated HttpRequestMessage.Properties with Options-based helpers
- mark optional request parameters and locals as nullable to fix nullability warnings
- add HttpRequestMessageOptionsExtensions for property bag support

## Testing
- `dotnet build` *(fails: Unable to find package Microsoft.Commerce.Payments.Authentication, Azure.Analytics.Experimentation.*)*

------
https://chatgpt.com/codex/tasks/task_e_689bcf66d5508329b6d7ce67166490a0