### PR TITLE
feat: migrate global configuration into program

### DIFF
--- a/net8/migration/PXService/Program.cs
+++ b/net8/migration/PXService/Program.cs
@@ -15,12 +15,20 @@ using Microsoft.Commerce.Payments.Common.Web;
 using Microsoft.Commerce.Payments.Common.Environments;
 using System.Diagnostics.Tracing;
 using Microsoft.Commerce.Payments.PXService.Handlers;
+using Microsoft.CommonSchema.Services.Listeners;
 using Environment = Microsoft.Commerce.Payments.Common.Environments.Environment;
 
 // If your custom handlers were ported to middleware, import their namespaces too:
 // using Microsoft.Commerce.Payments.PXService.Middleware;  // e.g., PXTraceCorrelationMiddleware, etc.
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Mirror Global.asax security protocol initialization
+ServicePointManager.SecurityProtocol &= ~(SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11);
+if (ServicePointManager.SecurityProtocol == 0)
+{
+    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+}
 
 // Create and register PX settings (mirrors Global.asax Application_Start)
 builder.Configuration
@@ -29,14 +37,14 @@ builder.Configuration
     .AddJsonFile("local.settings.json", optional: true)
     .AddEnvironmentVariables();
 
-string envTypeRaw = builder.Configuration["PXService:EnvironmentType"] ?? "Production";
-string envName = builder.Configuration["PXService:EnvironmentName"]
-                    ?? builder.Environment.EnvironmentName
-                    ?? "Production";
-
 var pxSettings = PXServiceSettings.CreateInstance(Environment.Current.EnvironmentType, Environment.Current.EnvironmentName);
 
 builder.Services.AddSingleton(pxSettings);
+
+// WebApiConfig settings
+ServicePointManager.CheckCertificateRevocationList = true;
+ApplicationInsightsProvider.SetupAppInsightsConfiguration(pxSettings.ApplicationInsightInstrumentKey, pxSettings.ApplicationInsightMode);
+EnsureSllInitialized();
 
 // Define supported API versions and controllers allowed without an explicit version
 var supportedVersions = new Dictionary<string, ApiVersion>(StringComparer.OrdinalIgnoreCase)
@@ -87,17 +95,31 @@ app.MapGet("/routes", (EndpointDataSource ds) =>
     Results.Text(string.Join(System.Environment.NewLine,
         ds.Endpoints.OfType<RouteEndpoint>().Select(e => e.RoutePattern.RawText))));
 
-if (pxSettings.ValidateCors)
+// Trace correlation (mirrors WebApiConfig)
+if (!WebHostingUtility.IsApplicationSelfHosted())
 {
-     app.UseMiddleware<PXServiceCorsHandler>(pxSettings);
+    app.UseMiddleware<PXTraceCorrelationHandler>(Constants.ServiceNames.PXService, ApplicationInsightsProvider.LogIncomingOperation);
 }
 
-// Ensure requests include a supported api-version and block unsupported ones
+// API version handler
 app.UseMiddleware<PXServiceApiVersionHandler>(supportedVersions, versionlessControllers, pxSettings);
+
+// CORS
+if (pxSettings.ValidateCors)
+{
+    app.UseMiddleware<PXServiceCorsHandler>(pxSettings);
+}
+
+// Input and PIDL validation handlers
+app.UseMiddleware<PXServiceInputValidationHandler>();
+if (pxSettings.PIDLDocumentValidationEnabled)
+{
+    app.UseMiddleware<PXServicePIDLValidationHandler>();
+}
 
 app.UseRouting();
 
-// 2) Gate requests using the resolver: if no controller is registered for (version, controller) -> 404
+// Gate requests using the resolver: if no controller is registered for (version, controller) -> 404
 app.Use(async (ctx, next) =>
 {
     var routeData = ctx.GetRouteData();
@@ -133,6 +155,12 @@ app.Lifetime.ApplicationStopping.Register(() =>
 app.Run();
 
 // ----------------- helpers -----------------
+static void EnsureSllInitialized()
+{
+    SllLogger.TraceMessage("Initialize SllLogger and Sll static dependencies.", EventLevel.Informational);
+    AuditLogger.Instantiate();
+}
+
 static void MapV7Routes(IEndpointRouteBuilder endpoints)
 {
     // Probe


### PR DESCRIPTION
## Summary
- move TLS and certificate checks into Program
- wire up Application Insights and SLL init
- add middleware for versioning, CORS, trace, and PIDL/input validation

## Testing
- `dotnet build net8/migration/PXService/PXService.csproj` *(fails: Unable to find package Microsoft.CommonSchema.Services and others)*

------
https://chatgpt.com/codex/tasks/task_e_689f7d042aec8329a06f8d9f2869aa4f