### PR TITLE
Add middleware entry point to PXServiceHandler

### DIFF
--- a/net8/migration/SelfHostedPXServiceCore/Mocks/PXServiceHandler.cs
+++ b/net8/migration/SelfHostedPXServiceCore/Mocks/PXServiceHandler.cs
@@ -6,6 +6,7 @@ namespace SelfHostedPXServiceCore.Mocks
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
 
     /// <summary>
     /// This is a delegating handler that allows callers to configure its behavior by setting custom actions
@@ -15,6 +16,8 @@ namespace SelfHostedPXServiceCore.Mocks
     /// </summary>
     public class PXServiceHandler : DelegatingHandler
     {
+        private readonly RequestDelegate _next;
+
         /// <summary>
         /// This action is called before sending the request to the next in the pipeline.
         /// </summary>
@@ -34,6 +37,20 @@ namespace SelfHostedPXServiceCore.Mocks
         public PXServiceHandler()
         {
             ResetToDefault();
+        }
+
+        public PXServiceHandler(RequestDelegate next)
+            : this()
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if (_next != null)
+            {
+                await _next(context);
+            }
         }
 
         public void ResetToDefault()


### PR DESCRIPTION
## Summary
- allow PXServiceHandler to be used as ASP.NET Core middleware by adding RequestDelegate constructor
- expose InvokeAsync pass-through

## Testing
- `dotnet build` *(fails: type or namespace name 'MockServiceWebRequestHandler' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc09856948329a0af4ae1a0a43509