### PR TITLE
refactor: centralize emulator setup via WebApiConfig

### DIFF
--- a/net8/migration/PXDependencyEmulators/Program.cs
+++ b/net8/migration/PXDependencyEmulators/Program.cs
@@ -4,9 +4,8 @@ using Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-builder.Services.AddControllers()
-    .AddNewtonsoftJson(); // Use Newtonsoft.Json for compatibility
+// Register services and scenario managers
+WebApiConfig.Register(builder);
 
 // Add Swagger services
 builder.Services.AddEndpointsApiExplorer();
@@ -34,24 +33,8 @@ if (app.Environment.IsDevelopment() || true)
     });
 }
 
-app.MapControllers();
-app.MapPartnerSettingsRoutes();
-app.MapPIMSRoutes();
-app.MapMSRewardsRoutes();
-app.MapCatalogRoutes();
-app.MapAccountRoutes();
-app.MapIssuerServiceRoutes();
-app.MapChallengeManagementRoutes();
-app.MapPaymentThirdPartyRoutes();
-app.MapPurchaseRoutes();
-app.MapRiskRoutes();
-app.MapSellerMarketPlaceRoutes();
-app.MapTokenPolicyRoutes();
-app.MapStoredValueRoutes();
-app.MapTransactionServiceRoutes();
-app.MapPaymentOchestratorRoutes();
-app.MapPayerAuthRoutes();
-app.MapFraudDetectionRoutes();
+// Map emulator routes
+WebApiConfig.MapRoutes(app);
 
 Console.WriteLine("PXDependencyEmulators is starting...");
 Console.WriteLine($"Application running on .NET {Environment.Version}");

--- a/net8/migration/PXDependencyEmulators/WebApiConfig.cs
+++ b/net8/migration/PXDependencyEmulators/WebApiConfig.cs
@@ -1,93 +1,149 @@
-﻿// <copyright file="WebApiConfig.cs" company="Microsoft">Copyright (c) Microsoft. All rights reserved.</copyright>
-
 namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators
 {
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Commerce.Payments.PXCommon;
-    using Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Mocks;
     using Test.Common;
 
-    public class WebApiConfig
+    /// <summary>
+    /// Provides configuration helpers for the dependency emulator service.
+    /// </summary>
+    public static class WebApiConfig
     {
-        public static void Register(HttpConfiguration config, bool useArrangedResponses = false)
+        /// <summary>
+        /// Registers services used by the dependency emulators.
+        /// </summary>
+        /// <param name="builder">The web application builder.</param>
+        /// <param name="useArrangedResponses">Indicates if arranged responses should be used.</param>
+        public static void Register(WebApplicationBuilder builder, bool useArrangedResponses = false)
         {
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new PartnerSettingsServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new AccountServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new PimsMockResponseProviderAugmented(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new MSRewardsServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new CatalogServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new IssuerServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new ChallengeManagementServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new PurchaseServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new RiskServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new TokenPolicyServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new StoredValueServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new WalletServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new TransactionDataServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new TransactionServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new PaymentOrchestratorServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new PayerAuthServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new FraudDetectionMockResponseProvider(), useArrangedResponses));
+            builder.Services.AddControllers()
+                .AddNewtonsoftJson();
 
-            // In Selfhost env, httpContext is not available due to which HttpContext.Current?.Server?.MapPath("~/TestScenarios")
-            // will return null. In such cases, we need to navigate to the TestScenarios folder from the current assembly path.
+            // Register scenario managers for the emulator responses.
             if (WebHostingUtility.IsApplicationSelfHosted())
             {
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PartnerSettings, "PXDependencyEmulators\\TestScenarios\\PartnerSettings", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Account, "PXDependencyEmulators\\TestScenarios\\Account", Constants.DefaultTestScenarios.AccountEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PIMS, "PXDependencyEmulators\\TestScenarios\\PIMS", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.MSRewards, "PXDependencyEmulators\\TestScenarios\\MSRewards", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Catalog, "PXDependencyEmulators\\TestScenarios\\Catalog", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.IssuerService, "PXDependencyEmulators\\TestScenarios\\IssuerService", Constants.DefaultTestScenarios.IssuerServiceEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.ChallengeManagement, "PXDependencyEmulators\\TestScenarios\\ChallengeManagement", Constants.DefaultTestScenarios.ChallengeManagementServiceEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PaymentThirdParty, "PXDependencyEmulators\\TestScenarios\\PaymentThirdParty", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Purchase, "PXDependencyEmulators\\TestScenarios\\Purchase", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Risk, "PXDependencyEmulators\\TestScenarios\\Risk", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.SellerMarketPlace, "PXDependencyEmulators\\TestScenarios\\SellerMarketPlace", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.TokenPolicy, "PXDependencyEmulators\\TestScenarios\\TokenPolicy", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.TransactionService, "PXDependencyEmulators\\TestScenarios\\TransactionService", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PaymentOchestrator, "PXDependencyEmulators\\TestScenarios\\PaymentOchestrator", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.FraudDetection, "PXDependencyEmulators\\TestScenarios\\FraudDetection", Constants.DefaultTestScenarios.FraudDetectionEmulator);
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.PartnerSettings,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\PartnerSettings", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.Account,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\Account", Constants.DefaultTestScenarios.AccountEmulator));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.PIMS,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\PIMS", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.MSRewards,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\MSRewards", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.Catalog,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\Catalog", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.IssuerService,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\IssuerService", Constants.DefaultTestScenarios.IssuerServiceEmulator));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.ChallengeManagement,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\ChallengeManagement", Constants.DefaultTestScenarios.ChallengeManagementServiceEmulator));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.PaymentThirdParty,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\PaymentThirdParty", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.Purchase,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\Purchase", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.Risk,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\Risk", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.SellerMarketPlace,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\SellerMarketPlace", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.TokenPolicy,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\TokenPolicy", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.TransactionService,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\TransactionService", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.PaymentOchestrator,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\PaymentOchestrator", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.FraudDetection,
+                    new TestScenarioManager("PXDependencyEmulators\\TestScenarios\\FraudDetection", Constants.DefaultTestScenarios.FraudDetectionEmulator));
             }
             else
             {
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Account, "~/TestScenarios/Account", Constants.DefaultTestScenarios.AccountEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PartnerSettings, "~/TestScenarios/PartnerSettings", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PIMS, "~/TestScenarios/PIMS", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.MSRewards, "~/TestScenarios/MSRewards", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Catalog, "~/TestScenarios/Catalog", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.IssuerService, "~/TestScenarios/IssuerService", Constants.DefaultTestScenarios.IssuerServiceEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.ChallengeManagement, "~/TestScenarios/ChallengeManagement", Constants.DefaultTestScenarios.ChallengeManagementServiceEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PaymentThirdParty, "~/TestScenarios/PaymentThirdParty", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Purchase, "~/TestScenarios/Purchase", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Risk, "~/TestScenarios/Risk", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.SellerMarketPlace, "~/TestScenarios/SellerMarketPlace", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.TokenPolicy, "~/TestScenarios/TokenPolicy", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.TransactionService, "~/TestScenarios/TransactionService", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PaymentOchestrator, "~/TestScenarios/PaymentOchestrator", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.FraudDetection, "~/TestScenarios/FraudDetection", Constants.DefaultTestScenarios.FraudDetectionEmulator);
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.Account,
+                    new TestScenarioManager("~/TestScenarios/Account", Constants.DefaultTestScenarios.AccountEmulator));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.PartnerSettings,
+                    new TestScenarioManager("~/TestScenarios/PartnerSettings", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.PIMS,
+                    new TestScenarioManager("~/TestScenarios/PIMS", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.MSRewards,
+                    new TestScenarioManager("~/TestScenarios/MSRewards", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.Catalog,
+                    new TestScenarioManager("~/TestScenarios/Catalog", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.IssuerService,
+                    new TestScenarioManager("~/TestScenarios/IssuerService", Constants.DefaultTestScenarios.IssuerServiceEmulator));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.ChallengeManagement,
+                    new TestScenarioManager("~/TestScenarios/ChallengeManagement", Constants.DefaultTestScenarios.ChallengeManagementServiceEmulator));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.PaymentThirdParty,
+                    new TestScenarioManager("~/TestScenarios/PaymentThirdParty", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.Purchase,
+                    new TestScenarioManager("~/TestScenarios/Purchase", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.Risk,
+                    new TestScenarioManager("~/TestScenarios/Risk", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.SellerMarketPlace,
+                    new TestScenarioManager("~/TestScenarios/SellerMarketPlace", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.TokenPolicy,
+                    new TestScenarioManager("~/TestScenarios/TokenPolicy", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.TransactionService,
+                    new TestScenarioManager("~/TestScenarios/TransactionService", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.PaymentOchestrator,
+                    new TestScenarioManager("~/TestScenarios/PaymentOchestrator", string.Empty));
+                builder.Services.RegisterScenarioManager(
+                    Constants.TestScenarioManagers.FraudDetection,
+                    new TestScenarioManager("~/TestScenarios/FraudDetection", Constants.DefaultTestScenarios.FraudDetectionEmulator));
             }
+        }
 
-            // Map routes for different emulators
-            config.Routes.MapAccountRoutes();
-            config.Routes.MapPartnerSettingsRoutes();
-            config.Routes.MapPIMSRoutes();
-            config.Routes.MapMSRewardsRoutes();
-            config.Routes.MapCatalogRoutes();
-
-            config.Routes.MapIssuerServiceRoutes();
-
-            config.Routes.MapChallengeManagementRoutes();
-            config.Routes.MapPaymentThirdPartyRoutes();
-            config.Routes.MapPurchaseRoutes();
-            config.Routes.MapRiskRoutes();
-            config.Routes.MapSellerMarketPlaceRoutes();
-            config.Routes.MapTokenPolicyRoutes();
-            config.Routes.MapStoredValueRoutes();
-            config.Routes.MapTransactionServiceRoutes();
-            config.Routes.MapPaymentOchestratorRoutes();
-            config.Routes.MapPayerAuthRoutes();
-            config.Routes.MapFraudDetectionRoutes();
+        /// <summary>
+        /// Maps emulator routes on the specified route builder.
+        /// </summary>
+        /// <param name="routes">The endpoint route builder.</param>
+        public static void MapRoutes(IEndpointRouteBuilder routes)
+        {
+            routes.MapControllers();
+            routes.MapPartnerSettingsRoutes();
+            routes.MapPIMSRoutes();
+            routes.MapMSRewardsRoutes();
+            routes.MapCatalogRoutes();
+            routes.MapAccountRoutes();
+            routes.MapIssuerServiceRoutes();
+            routes.MapChallengeManagementRoutes();
+            routes.MapPaymentThirdPartyRoutes();
+            routes.MapPurchaseRoutes();
+            routes.MapRiskRoutes();
+            routes.MapSellerMarketPlaceRoutes();
+            routes.MapTokenPolicyRoutes();
+            routes.MapStoredValueRoutes();
+            routes.MapTransactionServiceRoutes();
+            routes.MapPaymentOchestratorRoutes();
+            routes.MapPayerAuthRoutes();
+            routes.MapFraudDetectionRoutes();
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- use WebApiConfig for service registration and routing in PXDependencyEmulators
- add ASP.NET Core WebApiConfig with scenario manager registration and route mapping

## Testing
- `dotnet build net8/migration/PXDependencyEmulators/PXDependencyEmulators.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c3d7d8e88329a5be8fcc5a725dcc