### PR TITLE
refactor: migrate emulator base controller to new test scenario manager

### DIFF
--- a/net8/migration/PXDependencyEmulators/Controllers/EmulatorBaseController.cs
+++ b/net8/migration/PXDependencyEmulators/Controllers/EmulatorBaseController.cs
@@ -1,23 +1,29 @@
-﻿// <copyright file="EmulatorBaseController.cs" company="Microsoft">Copyright (c) Microsoft 2017. All rights reserved.</copyright>
+// <copyright file="EmulatorBaseController.cs" company="Microsoft">Copyright (c) Microsoft 2017. All rights reserved.</copyright>
 
 namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Controllers
 {
     using System;
     using System.Collections.Generic;
-    using System.Net.Http;
-    using System.Web.Http;
-    using Common.Transaction;
-    using Common.Web;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Commerce.Payments.Common.Transaction;
     using Test.Common;
+    using Test.Common.Extensions;
     using Constants = Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Constants;
 
-    public class EmulatorBaseController : ApiController
+    public class EmulatorBaseController : ControllerBase
     {
+        private readonly TestScenarioManager testScenarioManager;
         private readonly string testScenarioManagerName;
-        private readonly string defaultTestScenario;
+        private readonly string? defaultTestScenario;
 
-        public EmulatorBaseController(string testScenarioManagerName, string defaultTestScenario = null)
+        public EmulatorBaseController(
+            TestScenarioManager testScenarioManager,
+            string testScenarioManagerName,
+            string? defaultTestScenario = null)
         {
+            this.testScenarioManager = testScenarioManager;
             this.testScenarioManagerName = testScenarioManagerName;
             this.defaultTestScenario = defaultTestScenario;
             this.PlaceholderReplacements = new Dictionary<string, string>()
@@ -28,44 +34,42 @@ namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Cont
 
         protected Dictionary<string, string> PlaceholderReplacements { get; }
 
-        protected TestScenarioManager TestScenarioManager
+        protected async Task<IActionResult> GetResponseAsync(string apiName)
         {
-            get
+            if (!HttpContext.TryGetTestContext(out var testContext))
             {
-                return this.Configuration.GetTestScenarioManager(this.testScenarioManagerName);
+                if (!string.IsNullOrEmpty(this.defaultTestScenario))
+                {
+                    testContext = new TestContext(
+                        $"DependencyEmulator.{this.testScenarioManagerName}",
+                        DateTime.UtcNow,
+                        this.defaultTestScenario);
+                }
+                else
+                {
+                    return BadRequest("TestContext not found.");
+                }
             }
+
+            var result = this.testScenarioManager.GetResponseContent(apiName, testContext);
+            var responseContent = ReplacePlaceholders(result.Content);
+
+            HttpContext.Response.StatusCode = result.StatusCode;
+            HttpContext.Response.ContentType = result.ContentType ?? "application/json";
+
+            if (!string.IsNullOrEmpty(responseContent))
+            {
+                await HttpContext.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(responseContent));
+            }
+
+            return new EmptyResult();
         }
 
-        protected virtual HttpResponseMessage GetResponse(string apiName)
+        protected string ReplacePlaceholders(string? responseContent)
         {
-            TestContext testContext = null;
-
-            if (this.Request.TryGetTestContext(out testContext))
-            {
-                return TestScenarioManager.GetResponse(apiName, testContext);
-            }
-            else if (!string.IsNullOrEmpty(this.defaultTestScenario))
-            {
-                // Return response from default scenario
-                testContext = new TestContext($"DependencyEmulator.{this.testScenarioManagerName}", DateTime.UtcNow, this.defaultTestScenario);
-                
-                return TestScenarioManager.GetResponse(apiName, testContext);
-            }
-            else
-            {
-                // If the flow entering else that means the test context is not available and default test scenario is not provided
-                // and might return error from TestScenarioManager class, needs to be handled from devloper
-                return TestScenarioManager.GetResponse(apiName, testContext);
-            }
-        }
-
-        protected HttpResponseMessage ReplacePlaceholders(HttpResponseMessage response)
-        {
-            var responseContent = response?.Content?.ReadAsStringAsync().Result;
-
             if (string.IsNullOrEmpty(responseContent))
             {
-                return response;
+                return responseContent ?? string.Empty;
             }
 
             foreach (var kvp in this.PlaceholderReplacements)
@@ -73,9 +77,7 @@ namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Cont
                 responseContent = responseContent.Replace(kvp.Key, kvp.Value ?? string.Empty);
             }
 
-            response.Content = new StringContent(responseContent, System.Text.Encoding.UTF8, Test.Common.Constants.HeaderValues.JsonContent); // lgtm[cs/web/xss] Suppressing Semmle warning
-
-            return response;
+            return responseContent;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace legacy ApiController with ASP.NET Core ControllerBase
- wire TestScenarioManager and placeholder support into emulator response helper

## Testing
- `dotnet build net8/migration/PXDependencyEmulators/PXDependencyEmulators.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_68a4e8c88cf88329ae51765f0f102345