### PR TITLE
Add HttpResponseData model and content-based responses

### DIFF
--- a/net8/migration/Test.Common/HttpResponseData.cs
+++ b/net8/migration/Test.Common/HttpResponseData.cs
@@ -1,0 +1,9 @@
+namespace Test.Common
+{
+    public class HttpResponseData
+    {
+        public int StatusCode { get; set; }
+        public string? Content { get; set; }
+        public string? ContentType { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add `HttpResponseData` DTO for simplified response handling
- refactor `TestScenarioManager` to return `HttpResponseData` and build `HttpResponseMessage` from it

## Testing
- `dotnet build net8/migration/Test.Common/Test.Common.csproj` *(fails: The imported project "/msbuild/Environment.props" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f99dde4883299e17d9dc249be819