### PR TITLE
refactor: add core webapi config

### DIFF
--- a/net8/migration/PXDependencyEmulators/WebApiConfig.cs
+++ b/net8/migration/PXDependencyEmulators/WebApiConfig.cs
@@ -1,93 +1,75 @@
-﻿// <copyright file="WebApiConfig.cs" company="Microsoft">Copyright (c) Microsoft. All rights reserved.</copyright>
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Test.Common;
 
-namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators
+namespace Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators;
+
+/// <summary>
+/// ASP.NET Core configuration for the dependency emulators.
+/// </summary>
+public static class WebApiConfig
 {
-    using System.Web.Http;
-    using Microsoft.Commerce.Payments.PXCommon;
-    using Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.Mocks;
-    using Test.Common;
-
-    public class WebApiConfig
+    /// <summary>
+    /// Registers services and the <see cref="TestScenarioManager"/> instances used by the emulators.
+    /// </summary>
+    /// <param name="builder">The application builder.</param>
+    public static void Register(WebApplicationBuilder builder)
     {
-        public static void Register(HttpConfiguration config, bool useArrangedResponses = false)
+        builder.Services.AddControllers();
+
+        var env = builder.Environment;
+
+        var managers = new Dictionary<string, TestScenarioManager>
         {
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new PartnerSettingsServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new AccountServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new PimsMockResponseProviderAugmented(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new MSRewardsServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new CatalogServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new IssuerServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new ChallengeManagementServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new PurchaseServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new RiskServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new TokenPolicyServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new StoredValueServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new WalletServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new TransactionDataServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new TransactionServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new PaymentOrchestratorServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new PayerAuthServiceMockResponseProvider(), useArrangedResponses));
-            config.MessageHandlers.Add(new MockServiceDelegatingHandlerV2(new FraudDetectionMockResponseProvider(), useArrangedResponses));
+            [Constants.TestScenarioManagers.PartnerSettings] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "PartnerSettings"), Constants.DefaultTestScenarios.PartnerSettingsEmulator),
+            [Constants.TestScenarioManagers.Account] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "Account"), Constants.DefaultTestScenarios.AccountEmulator),
+            [Constants.TestScenarioManagers.PIMS] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "PIMS"), string.Empty),
+            [Constants.TestScenarioManagers.MSRewards] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "MSRewards"), Constants.DefaultTestScenarios.MSRewardsEmulator),
+            [Constants.TestScenarioManagers.Catalog] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "Catalog"), Constants.DefaultTestScenarios.CatalogEmulator),
+            [Constants.TestScenarioManagers.IssuerService] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "IssuerService"), Constants.DefaultTestScenarios.IssuerServiceEmulator),
+            [Constants.TestScenarioManagers.ChallengeManagement] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "ChallengeManagement"), Constants.DefaultTestScenarios.ChallengeManagementServiceEmulator),
+            [Constants.TestScenarioManagers.PaymentThirdParty] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "PaymentThirdParty"), string.Empty),
+            [Constants.TestScenarioManagers.Purchase] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "Purchase"), string.Empty),
+            [Constants.TestScenarioManagers.Risk] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "Risk"), Constants.DefaultTestScenarios.RiskEmulator),
+            [Constants.TestScenarioManagers.SellerMarketPlace] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "SellerMarketPlace"), Constants.DefaultTestScenarios.SellerMarketEmulator),
+            [Constants.TestScenarioManagers.TokenPolicy] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "TokenPolicy"), Constants.DefaultTestScenarios.TokenPolicyEmulator),
+            [Constants.TestScenarioManagers.TransactionService] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "TransactionService"), string.Empty),
+            [Constants.TestScenarioManagers.PaymentOchestrator] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "PaymentOchestrator"), Constants.DefaultTestScenarios.POEmulator),
+            [Constants.TestScenarioManagers.FraudDetection] = new TestScenarioManager(Path.Combine(env.ContentRootPath, "TestScenarios", "FraudDetection"), Constants.DefaultTestScenarios.FraudDetectionEmulator),
+        };
 
-            // In Selfhost env, httpContext is not available due to which HttpContext.Current?.Server?.MapPath("~/TestScenarios")
-            // will return null. In such cases, we need to navigate to the TestScenarios folder from the current assembly path.
-            if (WebHostingUtility.IsApplicationSelfHosted())
-            {
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PartnerSettings, "PXDependencyEmulators\\TestScenarios\\PartnerSettings", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Account, "PXDependencyEmulators\\TestScenarios\\Account", Constants.DefaultTestScenarios.AccountEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PIMS, "PXDependencyEmulators\\TestScenarios\\PIMS", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.MSRewards, "PXDependencyEmulators\\TestScenarios\\MSRewards", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Catalog, "PXDependencyEmulators\\TestScenarios\\Catalog", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.IssuerService, "PXDependencyEmulators\\TestScenarios\\IssuerService", Constants.DefaultTestScenarios.IssuerServiceEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.ChallengeManagement, "PXDependencyEmulators\\TestScenarios\\ChallengeManagement", Constants.DefaultTestScenarios.ChallengeManagementServiceEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PaymentThirdParty, "PXDependencyEmulators\\TestScenarios\\PaymentThirdParty", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Purchase, "PXDependencyEmulators\\TestScenarios\\Purchase", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Risk, "PXDependencyEmulators\\TestScenarios\\Risk", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.SellerMarketPlace, "PXDependencyEmulators\\TestScenarios\\SellerMarketPlace", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.TokenPolicy, "PXDependencyEmulators\\TestScenarios\\TokenPolicy", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.TransactionService, "PXDependencyEmulators\\TestScenarios\\TransactionService", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PaymentOchestrator, "PXDependencyEmulators\\TestScenarios\\PaymentOchestrator", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.FraudDetection, "PXDependencyEmulators\\TestScenarios\\FraudDetection", Constants.DefaultTestScenarios.FraudDetectionEmulator);
-            }
-            else
-            {
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Account, "~/TestScenarios/Account", Constants.DefaultTestScenarios.AccountEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PartnerSettings, "~/TestScenarios/PartnerSettings", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PIMS, "~/TestScenarios/PIMS", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.MSRewards, "~/TestScenarios/MSRewards", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Catalog, "~/TestScenarios/Catalog", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.IssuerService, "~/TestScenarios/IssuerService", Constants.DefaultTestScenarios.IssuerServiceEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.ChallengeManagement, "~/TestScenarios/ChallengeManagement", Constants.DefaultTestScenarios.ChallengeManagementServiceEmulator);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PaymentThirdParty, "~/TestScenarios/PaymentThirdParty", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Purchase, "~/TestScenarios/Purchase", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.Risk, "~/TestScenarios/Risk", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.SellerMarketPlace, "~/TestScenarios/SellerMarketPlace", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.TokenPolicy, "~/TestScenarios/TokenPolicy", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.TransactionService, "~/TestScenarios/TransactionService", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.PaymentOchestrator, "~/TestScenarios/PaymentOchestrator", string.Empty);
-                config.RegisterScenarioManager(Constants.TestScenarioManagers.FraudDetection, "~/TestScenarios/FraudDetection", Constants.DefaultTestScenarios.FraudDetectionEmulator);
-            }
+        builder.Services.AddSingleton(managers);
+    }
 
-            // Map routes for different emulators
-            config.Routes.MapAccountRoutes();
-            config.Routes.MapPartnerSettingsRoutes();
-            config.Routes.MapPIMSRoutes();
-            config.Routes.MapMSRewardsRoutes();
-            config.Routes.MapCatalogRoutes();
+    /// <summary>
+    /// Configures the conventional routes for the emulator controllers.
+    /// </summary>
+    /// <param name="routes">The application's route builder.</param>
+    public static void ConfigureRoutes(IEndpointRouteBuilder routes)
+    {
+        routes.MapControllers();
 
-            config.Routes.MapIssuerServiceRoutes();
-
-            config.Routes.MapChallengeManagementRoutes();
-            config.Routes.MapPaymentThirdPartyRoutes();
-            config.Routes.MapPurchaseRoutes();
-            config.Routes.MapRiskRoutes();
-            config.Routes.MapSellerMarketPlaceRoutes();
-            config.Routes.MapTokenPolicyRoutes();
-            config.Routes.MapStoredValueRoutes();
-            config.Routes.MapTransactionServiceRoutes();
-            config.Routes.MapPaymentOchestratorRoutes();
-            config.Routes.MapPayerAuthRoutes();
-            config.Routes.MapFraudDetectionRoutes();
-        }
+        routes.MapAccountRoutes();
+        routes.MapPartnerSettingsRoutes();
+        routes.MapPIMSRoutes();
+        routes.MapMSRewardsRoutes();
+        routes.MapCatalogRoutes();
+        routes.MapIssuerServiceRoutes();
+        routes.MapChallengeManagementRoutes();
+        routes.MapPaymentThirdPartyRoutes();
+        routes.MapPurchaseRoutes();
+        routes.MapRiskRoutes();
+        routes.MapSellerMarketPlaceRoutes();
+        routes.MapTokenPolicyRoutes();
+        routes.MapStoredValueRoutes();
+        routes.MapTransactionServiceRoutes();
+        routes.MapPaymentOchestratorRoutes();
+        routes.MapPayerAuthRoutes();
+        routes.MapFraudDetectionRoutes();
     }
 }
+


### PR DESCRIPTION
## Summary
- resolve test scenario managers from dependency injection and add HTTP helpers for legacy controllers
- replace legacy WebApiConfig with ASP.NET Core setup and route mapping

## Testing
- `dotnet build net8/migration/PXDependencyEmulators/PXDependencyEmulators.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a503cd3bb8832987b607724a7f7731