### PR TITLE
refactor: replace HttpRequestMessage.Properties

### DIFF
--- a/net8/migration/Common/OpenTelemetry/SllWebLogger.cs
+++ b/net8/migration/Common/OpenTelemetry/SllWebLogger.cs
@@ -65,22 +65,18 @@ namespace Microsoft.Commerce.Payments.Common.OpenTelemetry
         {
             // Not all the APIs have version.
             string apiExternalVersion = string.Empty;
-            if (request.Properties.ContainsKey(PaymentConstants.Web.Properties.Version))
+            if (request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.Version), out _))
             {
                 apiExternalVersion = request.GetApiVersion().ExternalVersion;
             }
 
-            object callerObject;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.CallerName, out callerObject);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.CallerName), out var callerObject);
 
-            object callerThumbprintObject;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.CallerThumbprint, out callerThumbprintObject);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.CallerThumbprint), out var callerThumbprintObject);
 
-            object flightingExperimentId;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.FlightingExperimentId, out flightingExperimentId);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.FlightingExperimentId), out var flightingExperimentId);
 
-            object scenarioId;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.ScenarioId, out scenarioId);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.ScenarioId), out var scenarioId);
 
             Ms.Qos.ServiceRequestStatus operationStatus = Ms.Qos.ServiceRequestStatus.Undefined;
 
@@ -186,13 +182,12 @@ namespace Microsoft.Commerce.Payments.Common.OpenTelemetry
         {
             // Not all the APIs have version.
             string apiExternalVersion = string.Empty;
-            if (request.Properties.ContainsKey(PaymentConstants.Web.Properties.Version))
+            if (request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.Version), out _))
             {
                 apiExternalVersion = request.GetApiVersion().ExternalVersion;
             }
 
-            object callerObject;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.CallerName, out callerObject);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.CallerName), out var callerObject);
 
             ServiceRequestStatus operationStatus = ServiceRequestStatus.Undefined;
 
@@ -309,7 +304,7 @@ namespace Microsoft.Commerce.Payments.Common.OpenTelemetry
         {
             // Not all the APIs have version.
             object apiVersion = null;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.Version, out apiVersion);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.Version), out apiVersion);
 
             Ms.Qos.ServiceRequestStatus operationStatus = Ms.Qos.ServiceRequestStatus.Undefined;
 

--- a/net8/migration/Common/Web/HttpRequestMessageExtensions.cs
+++ b/net8/migration/Common/Web/HttpRequestMessageExtensions.cs
@@ -574,9 +574,10 @@ namespace Microsoft.Commerce.Payments.Common.Web
         public static bool TryGetQueryParameterValue(this HttpRequestMessage request, string parameterName, out string parameterValue, string objectNamePattern = null)
         {
             IEnumerable<KeyValuePair<string, string>> queryStrings = null;
-            if (request.Properties.ContainsKey(PaymentConstants.Web.Properties.QueryParameters))
+            if (request.TryGetOption(PaymentConstants.Web.Properties.QueryParameters, out var cached) &&
+                cached is IEnumerable<KeyValuePair<string, string>> cachedQueries)
             {
-                queryStrings = request.Properties[PaymentConstants.Web.Properties.QueryParameters] as IEnumerable<KeyValuePair<string, string>>;
+                queryStrings = cachedQueries;
             }
 
             if (queryStrings == null)
@@ -584,7 +585,7 @@ namespace Microsoft.Commerce.Payments.Common.Web
                 queryStrings = request.GetQueryNameValuePairs();
                 if (queryStrings != null)
                 {
-                    request.Properties.Add(new KeyValuePair<string, object>(PaymentConstants.Web.Properties.QueryParameters, queryStrings));
+                    request.SetOption(PaymentConstants.Web.Properties.QueryParameters, queryStrings);
                 }
             }
 
@@ -703,7 +704,7 @@ namespace Microsoft.Commerce.Payments.Common.Web
 
         public static HttpContext? GetHttpContext(this HttpRequestMessage request)
         {
-            if (request.Properties.TryGetValue("MS_HttpContext", out var context) && context is HttpContext httpContext)
+            if (request.TryGetOption("MS_HttpContext", out var context) && context is HttpContext httpContext)
             {
                 return httpContext;
             }

--- a/net8/migration/Common/Web/SllWebLogger.cs
+++ b/net8/migration/Common/Web/SllWebLogger.cs
@@ -55,16 +55,14 @@ namespace Microsoft.Commerce.Payments.Common.Web
         {
             // Not all the APIs have version.
             string apiExternalVersion = string.Empty;
-            if (request.Properties.ContainsKey(PaymentConstants.Web.Properties.Version))
+            if (request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.Version), out _))
             {
                 apiExternalVersion = request.GetApiVersion().ExternalVersion;
             }
 
-            object callerObject;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.CallerName, out callerObject);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.CallerName), out var callerObject);
 
-            object callerThumbprintObject;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.CallerThumbprint, out callerThumbprintObject);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.CallerThumbprint), out var callerThumbprintObject);
 
             Ms.Qos.ServiceRequestStatus operationStatus = Ms.Qos.ServiceRequestStatus.Undefined;
 
@@ -133,14 +131,12 @@ namespace Microsoft.Commerce.Payments.Common.Web
                 SllLogger.EnvironmentLogOption,
                 (envelope) =>
                 {
-                    object flightingExperimentId;
-                    if (request.Properties.TryGetValue(PaymentConstants.Web.Properties.FlightingExperimentId, out flightingExperimentId))
+                    if (request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.FlightingExperimentId), out var flightingExperimentId))
                     {
                         envelope.SetApp(new Telemetry.Extensions.app { expId = flightingExperimentId.ToString() });
                     }
 
-                    object scenarioId;
-                    if (request.Properties.TryGetValue(PaymentConstants.Web.Properties.ScenarioId, out scenarioId) && envelope.tags != null)
+                    if (request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.ScenarioId), out var scenarioId) && envelope.tags != null)
                     {
                         envelope.tags["scenarioId"] = scenarioId.ToString();
                     }
@@ -201,13 +197,12 @@ namespace Microsoft.Commerce.Payments.Common.Web
         {
             // Not all the APIs have version.
             string apiExternalVersion = string.Empty;
-            if (request.Properties.ContainsKey(PaymentConstants.Web.Properties.Version))
+            if (request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.Version), out _))
             {
                 apiExternalVersion = request.GetApiVersion().ExternalVersion;
             }
 
-            object callerObject;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.CallerName, out callerObject);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.CallerName), out var callerObject);
 
             ServiceRequestStatus operationStatus = ServiceRequestStatus.Undefined;
 
@@ -332,7 +327,7 @@ namespace Microsoft.Commerce.Payments.Common.Web
         {
             // Not all the APIs have version.
             object apiVersion = null;
-            request.Properties.TryGetValue(PaymentConstants.Web.Properties.Version, out apiVersion);
+            request.Options.TryGetValue(new HttpRequestOptionsKey<object>(PaymentConstants.Web.Properties.Version), out apiVersion);
 
             Ms.Qos.ServiceRequestStatus operationStatus = Ms.Qos.ServiceRequestStatus.Undefined;
 


### PR DESCRIPTION
## Summary
- replace obsolete `HttpRequestMessage.Properties` with `Options` across Common components
- update query parameter and HTTP context handling to use Options
- store tracing metadata via Options in TraceCorrelationHandler

## Testing
- `dotnet build` *(fails: The PackageReference items Microsoft.AspNetCore.Mvc.Core; Microsoft.AspNetCore.Mvc.Analyzers do not have corresponding PackageVersion)*

------
https://chatgpt.com/codex/tasks/task_e_68a53342d6bc8329ac60d7fb6ed6088b