### PR TITLE
fix: prioritize conventional routing for versioned APIs

### DIFF
--- a/net8/migration/SelfHostedPXServiceCore/HostableService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/HostableService.cs
@@ -58,6 +58,14 @@
 
             SelfHostServer = builder.Build();
 
+            // Map conventional routes before attribute routes so that
+            // versioned URL patterns registered via MapControllerRoute are
+            // evaluated ahead of any attribute based routes on the
+            // controllers.  This mirrors the precedence Web API 2 provided
+            // and prevents attributes like [Route("{version}")] from
+            // unintentionally shadowing the conventional mappings.
+            configureRoutes?.Invoke(SelfHostServer);
+
             SelfHostServer.MapControllers();
 
             SelfHostServer.MapGet("/routes", (EndpointDataSource ds) =>
@@ -123,7 +131,6 @@
                 await next();
             });
 
-            configureRoutes?.Invoke(SelfHostServer);
             SelfHostServer.StartAsync().Wait();
 
             HttpSelfHttpClient = new HttpClient

--- a/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
@@ -117,7 +117,7 @@ namespace SelfHostedPXServiceCore
                     WebApiConfig.Register(builder, PXSettings);
                     PXFlightHandler = new PXServiceFlightHandler();
                     builder.Services.AddSingleton(PXFlightHandler);
-                  
+
                     // The PXCorsHandler instance here is for testing purposes.
                     // It needs to be added after WebApiConfig.Register runs otherwise the flight needed for testing will be overwritten.
                     PXCorsHandler = new PXServiceCorsHandler(new PXServiceSettings());
@@ -130,7 +130,7 @@ namespace SelfHostedPXServiceCore
                 },
                 fullBaseUrl,
                 "http",
-                WebApiConfig.AddUrlVersionedRoutes);
+                configureRoutes: WebApiConfig.AddUrlVersionedRoutes);
         }
 
         public void ResetDependencies()

--- a/net8/migration/SelfHostedPXServiceCore/WebApiConfig.cs
+++ b/net8/migration/SelfHostedPXServiceCore/WebApiConfig.cs
@@ -45,9 +45,11 @@ namespace Microsoft.Commerce.Payments.PXService
         public static void AddUrlVersionedRoutes(IEndpointRouteBuilder routes)
         {
             // V7 Routes
+            // Include the API version as an explicit path segment for the
+            // probe endpoint so calls like /v7.0/probe are routed correctly.
             routes.MapControllerRoute(
                 name: GlobalConstants.V7RouteNames.Probe,
-                pattern: GlobalConstants.EndPointNames.V7Probe,
+                pattern: "{version}/" + GlobalConstants.EndPointNames.V7Probe,
                 defaults: new { controller = GlobalConstants.ControllerNames.ProbeController, action = "Get" });
 
             routes.MapControllerRoute(


### PR DESCRIPTION
## Summary
- map conventional routes before attribute routes to avoid shadowing versioned endpoints
- wire up versioned route mapping explicitly during self-host init
- include version segment in probe route pattern for /v7.0/probe

## Testing
- `dotnet build` *(fails: The imported project "/msbuild/Environment.props" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a63ce8cad88329ae0d39ea38d5c76f