### PR TITLE
Wire PXService API version handler for SendAsync logic

### DIFF
--- a/net8/migration/PXService/PXServiceApiVersionHandler.cs
+++ b/net8/migration/PXService/PXServiceApiVersionHandler.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
+    using System.Net.Http;
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
@@ -59,7 +60,7 @@ namespace Microsoft.Commerce.Payments.PXService
             this.settings = settings;
         }
 
-        public async Task InvokeAsync(AspNetCore.Http.HttpContext httpContext)
+        public async Task InvokeAsync(HttpContext httpContext)
         {
             var allowedVersionlessRequest = false;
             var endpoint = httpContext.GetEndpoint();

--- a/net8/migration/PXService/PXServiceApiVersionHandler.cs
+++ b/net8/migration/PXService/PXServiceApiVersionHandler.cs
@@ -23,10 +23,10 @@ namespace Microsoft.Commerce.Payments.PXService
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Delegating handler which validates that an appropriate api-version is
+    /// Middleware which validates that an appropriate api-version is
     /// passed with the request.
     /// </summary>
-    public class PXServiceApiVersionHandler : DelegatingHandler
+    public class PXServiceApiVersionHandler
     {
         private const string OperationVersionHeader = "x-ms-operation-version";
         private const string ExposableFlightsHeader = "x-ms-flight";
@@ -35,28 +35,24 @@ namespace Microsoft.Commerce.Payments.PXService
         private const string PXFlightAssignmentContextHeader = "x-ms-px-flight-assignmentcontext";
         private const string NoSniff = "nosniff";
 
-        private string[] versionlessControllers;
-        private IDictionary<string, ApiVersion> supportedVersions;
-        private PXServiceSettings settings;
-        private readonly RequestDelegate? next;
+        private readonly string[] versionlessControllers;
+        private readonly IDictionary<string, ApiVersion> supportedVersions;
+        private readonly PXServiceSettings settings;
+        private readonly RequestDelegate next;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PXServiceApiVersionHandler"/> class.
         /// </summary>
+        /// <param name="next">The next middleware in the pipeline.</param>
         /// <param name="supportedVersions">A dictionary from api-version string to internal
         /// version number which represents the set of supported versions.</param>
-        /// <param name="versionlessControllers">Names of controllers that should be available with no version</param>
+        /// <param name="versionlessControllers">Names of controllers that should be available with no version.</param>
         /// <param name="settings">PXServiceSettings instance for the current service.</param>
-        public PXServiceApiVersionHandler(IDictionary<string, ApiVersion> supportedVersions, string[] versionlessControllers, PXServiceSettings settings)
-            : this(null, supportedVersions, versionlessControllers, settings)
-        {
-        }
-
-        public PXServiceApiVersionHandler(RequestDelegate? next, IDictionary<string, ApiVersion> supportedVersions, string[] versionlessControllers, PXServiceSettings settings)
+        public PXServiceApiVersionHandler(RequestDelegate next, IDictionary<string, ApiVersion> supportedVersions, string[] versionlessControllers, PXServiceSettings settings)
         {
             this.next = next;
             this.supportedVersions = supportedVersions;
-            this.versionlessControllers = versionlessControllers ?? new string[0];
+            this.versionlessControllers = versionlessControllers ?? Array.Empty<string>();
             this.settings = settings;
         }
 
@@ -110,11 +106,8 @@ namespace Microsoft.Commerce.Payments.PXService
 
             if (allowedVersionlessRequest)
             {
-                if (this.next != null)
-                {
-                    // If we have a next handler, call it
-                    await this.next(httpContext);
-                }
+                // If we have a next handler, call it
+                await this.next(httpContext);
                 return;
             }
 
@@ -156,7 +149,7 @@ namespace Microsoft.Commerce.Payments.PXService
         /// <param name="cancellationToken">A token which may be used to listen
         /// for cancellation.</param>
         /// <returns>The outbound response.</returns>
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             // Extract version and accountId from the RequestUri.
             // As can be seen from sample PX RequestUris below, version ("v7.0" in the example below) is part of the url.  Also,

--- a/net8/migration/PXService/WebApiConfig.cs
+++ b/net8/migration/PXService/WebApiConfig.cs
@@ -47,6 +47,11 @@ namespace Microsoft.Commerce.Payments.PXService
 
             string[] versionlessControllers = { GlobalConstants.ControllerNames.ProbeController };
             builder.Services.AddSingleton(versionlessControllers);
+            builder.Services.AddSingleton<IDictionary<string, ApiVersion>>(sp =>
+            {
+                var selectorInstance = sp.GetRequiredService<VersionedControllerSelector>();
+                return selectorInstance.SupportedVersions;
+            });
 
             //if (settings.ValidateCors)
             //{

--- a/net8/migration/PXService/WebApiConfig.cs
+++ b/net8/migration/PXService/WebApiConfig.cs
@@ -45,12 +45,13 @@ namespace Microsoft.Commerce.Payments.PXService
                 return selector;
             });
 
-            builder.Services.AddSingleton<PXServiceApiVersionHandler>(sp =>
+            builder.Services.AddSingleton<IDictionary<string, ApiVersion>>(sp =>
             {
                 var selector = sp.GetRequiredService<VersionedControllerSelector>();
-                string[] versionlessControllers = { GlobalConstants.ControllerNames.ProbeController };
-                return new PXServiceApiVersionHandler(selector.SupportedVersions, versionlessControllers, settings);
+                return selector.SupportedVersions;
             });
+
+            builder.Services.AddSingleton<string[]>(new[] { GlobalConstants.ControllerNames.ProbeController });
 
             //if (settings.ValidateCors)
             //{

--- a/net8/migration/PXService/WebApiConfig.cs
+++ b/net8/migration/PXService/WebApiConfig.cs
@@ -45,12 +45,11 @@ namespace Microsoft.Commerce.Payments.PXService
                 return selector;
             });
 
-            string[] versionlessControllers = { GlobalConstants.ControllerNames.ProbeController };
-            builder.Services.AddSingleton(versionlessControllers);
-            builder.Services.AddSingleton<IDictionary<string, ApiVersion>>(sp =>
+            builder.Services.AddSingleton<PXServiceApiVersionHandler>(sp =>
             {
-                var selectorInstance = sp.GetRequiredService<VersionedControllerSelector>();
-                return selectorInstance.SupportedVersions;
+                var selector = sp.GetRequiredService<VersionedControllerSelector>();
+                string[] versionlessControllers = { GlobalConstants.ControllerNames.ProbeController };
+                return new PXServiceApiVersionHandler(selector.SupportedVersions, versionlessControllers, settings);
             });
 
             //if (settings.ValidateCors)


### PR DESCRIPTION
## Summary
- ensure PXServiceApiVersionHandler has required System.Net.Http dependencies and uses HttpContext directly
- register supported API versions in WebApiConfig so the handler receives them via DI

## Testing
- `dotnet build net8/migration/PXService/PXService.csproj` *(fails: Unable to find package OpenTelemetry.Audit.Geneva)*

------
https://chatgpt.com/codex/tasks/task_e_68a8acc177d48329bd7bd42ac6038a6e