### PR TITLE
Fix endpoint routing for self-hosted PX service

### DIFF
--- a/net8/migration/PXService/WebApiConfig.cs
+++ b/net8/migration/PXService/WebApiConfig.cs
@@ -494,6 +494,9 @@ namespace Microsoft.Commerce.Payments.PXService
                 name: GlobalConstants.V7RouteNames.RemoveEligiblePaymentmethodsPaymentRequestExApi,
                 pattern: GlobalConstants.EndPointNames.V7RemoveEligiblePaymentmethodsPaymentRequestsEx,
                 defaults: new { controller = C(GlobalConstants.ControllerNames.PaymentRequestsExController), action = "RemoveEligiblePaymentMethods" });
+
+            // Also expose any attribute-routed controllers
+            endpoints.MapControllers();
         }
 
         private static void InitVersionSelector(VersionedControllerSelector selector)

--- a/net8/migration/SelfHostedPXService/Program.cs
+++ b/net8/migration/SelfHostedPXService/Program.cs
@@ -10,15 +10,9 @@ internal sealed class Program
 {
     public static async Task Main(string[] args)
     {
-        // Optional arg 0 was a base URL in the old model.
-        // For in-memory hosting we ignore the URL (no sockets are opened).
-        _ = (args.Length > 0) ? args[0] : null;
-
-        // Spin up the PX service and all its dependency emulators in memory.
-        // The “true, false” flags match your old usage:
-        //   useSelfHostedDependencies: true
-        //   useArrangedResponses:      false
-        using var host = SelfHostedPxService.StartInMemory(useSelfHostedDependencies: true, useArrangedResponses: false);
+        // Spin up the PX service and all its dependency emulators in memory with
+        // routing configured so HttpContext.GetEndpoint() resolves correctly.
+        using var host = SelfHostedPxService.StartInMemory(true, false);
 
         // Warm up like before (no real network I/O; this goes through TestServer).
         var relativeUrl = "users/me/paymentMethodDescriptions?country=tr&family=credit_card&type=mc&language=en-US&partner=storify&operation=add";

--- a/net8/migration/SelfHostedPXServiceCore/HostableService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/HostableService.cs
@@ -96,32 +96,18 @@ namespace SelfHostedPXServiceCore
             }
 
             // Ensure the routing matcher runs before custom middleware so HttpContext.GetEndpoint()
-            // is populated when those middlewares execute. Endpoints must be registered before the
-            // matcher is built, so controller routes are added inside UseEndpoints which runs after
-            // our custom middleware.
+            // is populated when those middlewares execute.
             App.UseRouting();
 
             // Callers can add middlewares, filters, etc. They will execute after routing but before
             // the selected endpoint is invoked.
             configureApp?.Invoke(App);
 
-            if (configureEndpoints != null)
-            {
-                // Map attribute/route-based controllers and finalize the endpoint pipeline
-                App.UseEndpoints(endpoints =>
-                {
-                    configureEndpoints?.Invoke(endpoints);
-                    endpoints.MapControllers();
-                });
-            }
-            else
-            {
-                // Map attribute/route-based controllers and finalize the endpoint pipeline
-                App.UseEndpoints(endpoints =>
-                {
-                    endpoints.MapControllers();
-                });
-            }
+            // Allow callers to register conventional routes prior to mapping controllers
+            configureEndpoints?.Invoke(App);
+
+            // Map attribute/route-based controllers and finalize the endpoint pipeline
+            App.MapControllers();
 
             // Start server
             App.Start();


### PR DESCRIPTION
## Summary
- ensure self-hosted PX service configures endpoint routing
- register conventional and attribute routes for controllers

## Testing
- `dotnet build net8/migration/SelfHostedPXService/SelfHostedPXService.csproj` *(fails: The imported project "/msbuild/Environment.props" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f313f64832985347d0866dcb3f4