### PR TITLE
Ensure mock PXServiceSettings is registered in self-hosted service

### DIFF
--- a/net8/migration/SelfHostedPXServiceCore/SelfHostedBootstrap.cs
+++ b/net8/migration/SelfHostedPXServiceCore/SelfHostedBootstrap.cs
@@ -1,48 +1,277 @@
-using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Commerce.Payments.PXService;
-using Microsoft.Commerce.Payments.PXService.Settings;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Commerce.Payments.PXService.Accessors.IssuerService;
+using Microsoft.Commerce.Payments.PXService.Accessors.MSRewardsService;
+using Microsoft.Commerce.Payments.PXService.Accessors.PartnerSettingsService;
+using Microsoft.Commerce.Payments.PXService.Accessors.TokenPolicyService;
+using Microsoft.Commerce.Payments.PXService.Model.PayerAuthService;
+using Microsoft.Commerce.Payments.PXService.RiskService.V7;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Protocol.Handlers;
+using SelfHostedPXServiceCore.Mocks;
+using System;
+using System.Net.Http;
+using System.Net.NetworkInformation;
+using System.Web.Services.Description;
+using static QRCoder.PayloadGenerator;
 
 namespace SelfHostedPXServiceCore
 {
     /// <summary>
-    /// Central bootstrap for configuring the in-memory PX service so that
-    /// endpoint routing is wired the same way as the full self-host.
+    /// Lightweight PX host that runs the service in memory using <see cref="TestServer"/>.
     /// </summary>
-    internal static class SelfHostedBootstrap
+    public sealed class SelfHostedPxService : IDisposable
     {
+        public static List<int> PreRegisteredPorts { get; private set; } = new();
+
+        public static Uri PXBaseUri = new Uri("https://localhost:7151");
+
+        public static HostableService PxHostableService { get; private set; }
+
+        public static Dictionary<Type, HostableService> SelfHostedDependencies { get; private set; }
+
+        public static PXServiceSettings PXSettings { get; private set; }
+
+        public static PXServiceHandler? PXHandler { get; private set; }
+
+        public static HttpClient PXClient { get; private set; }
+
+        public static PXServiceCorsHandler PXCorsHandler { get; private set; }
+
+        public static PXServiceFlightHandler PXFlightHandler { get; private set; }
+
+        /// <summary>HttpClient wired to the in-memory PX service.</summary>
+        public HttpClient HttpSelfHttpClient { get; private set; } = default!;
+
+        public IHost SelfHost = default!;
+
         /// <summary>
-        /// Register PX controllers and supporting services.
+        /// Spin up the PX service entirely in-memory. The returned client can be used to issue HTTP
+        /// requests without opening any network sockets.
         /// </summary>
-        public static void ConfigureServices(
-            WebApplicationBuilder builder,
-            Dictionary<Type, HostableService>? selfHostedDependencies,
-            bool useArrangedResponses)
+        public static SelfHostedPxService StartInMemory(string baseUrl, bool useSelfHostedDependencies, bool useArrangedResponses)
         {
-            var settings = new Mocks.PXServiceSettings(
-                selfHostedDependencies,
+            var selfHostedDependencies = new Dictionary<Type, HostableService>();
+
+            if (useSelfHostedDependencies)
+            {
+                // Start up dependency emulators first so PX can connect to them.
+                // in different host with available port.
+                selfHostedDependencies = ConfigureDependencies(baseUrl);
+            }
+
+            if (string.IsNullOrEmpty(baseUrl))
+            {
+                var port = GetAvailablePort();
+                var protocol = "https";
+                baseUrl = string.Format("{0}://localhost:{1}", protocol, port);
+                PXBaseUri = new Uri(baseUrl);
+            }
+            else
+            {
+                PXBaseUri = new Uri(baseUrl);
+            }
+
+            // Dependencies need to selfhost before px, we need to reserve px
+            // port so other dependencies don't take it.
+            PreRegisteredPorts.Add(PXBaseUri.Port);
+
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions());
+            // builder.WebHost.UseTestServer();
+
+            PXServiceSettings PXSettings = new Mocks.PXServiceSettings(
+                useSelfHostedDependencies ? selfHostedDependencies : null,
                 useArrangedResponses);
 
-            // Register the concrete mock settings so tests can resolve the type directly.
-            // WebApiConfig.Register will also register the base PXServiceSettings type.
-            builder.Services.AddSingleton(settings);
+            WebApiConfig.Register(builder, PXSettings);
 
-            WebApiConfig.Register(builder, settings);
+            var app = builder.Build();
+
+            ConfigurePipeline(app);
+
+            app.Start();
+
+            // 4) Expose handles
+            var svc = new SelfHostedPxService
+            {
+                SelfHost = app,
+                HttpSelfHttpClient = new HttpClient { BaseAddress = PXBaseUri },
+            };
+
+            PXClient = svc.HttpSelfHttpClient;
+            // Pull optional handlers if you registered them in DI
+            PXHandler = svc.SelfHost.Services.GetService<PXServiceHandler>();
+            PXCorsHandler = svc.SelfHost.Services.GetService<PXServiceCorsHandler>();
+            PXFlightHandler = svc.SelfHost.Services.GetService<PXServiceFlightHandler>();
+
+            return svc;
+        }
+
+        public void Dispose()
+        {
+            try { HttpSelfHttpClient?.Dispose(); } catch { }
+            try { SelfHost?.Dispose(); } catch { }
+
         }
 
         /// <summary>
-        /// Configure middleware and map conventional routes. Routing is
-        /// already enabled by <see cref="HostableService"/> so this simply adds
-        /// PX-specific handlers and versioned endpoints.
+        /// Configure the middleware pipeline and map routes.
         /// </summary>
         public static void ConfigurePipeline(WebApplication app)
         {
+            app.UseRouting();
+
+            // Log the matched endpoint so we can confirm HttpContext.GetEndpoint()
+            // has been populated by the routing middleware.
+            app.Use(async (ctx, next) =>
+            {
+                var ep = ctx.GetEndpoint();
+                Console.WriteLine($"[SelfHostedPxService] Endpoint: {ep?.DisplayName ?? "(null)"}");
+                await next();
+            });
+
             app.UseMiddleware<PXServiceApiVersionHandler>();
 
             WebApiConfig.AddUrlVersionedRoutes(app);
+
+            // Ensure endpoint middleware is registered so the selected action runs.
+            app.MapControllers();
+        }
+
+        public static string GetAvailablePort()
+        {
+            var netProperties = IPGlobalProperties.GetIPGlobalProperties();
+            var tcpListeners = netProperties.GetActiveTcpListeners();
+            var udpListeners = netProperties.GetActiveUdpListeners();
+
+            var portsInUse = new List<int>();
+            portsInUse.AddRange(tcpListeners.Select(tl => tl.Port));
+            portsInUse.AddRange(udpListeners.Select(ul => ul.Port));
+
+            int firstAvailablePort = 0;
+            for (int port = 49152; port < 65535; port++)
+            {
+                if (!portsInUse.Contains(port) && !PreRegisteredPorts.Contains(port))
+                {
+                    firstAvailablePort = port;
+                    break;
+                }
+            }
+
+            return firstAvailablePort.ToString();
+        }
+
+        public static Dictionary<Type, HostableService> ConfigureDependencies(string fullBaseUrl = "", string protocol = "https")
+        {
+            // Decide base URL
+            if (string.IsNullOrWhiteSpace(fullBaseUrl))
+            {
+                var p = GetAvailablePort();
+                var scheme = string.IsNullOrWhiteSpace(protocol) ? "http" : protocol!;
+                PXBaseUri = new Uri($"{scheme}://localhost:{p.ToString()}");
+            }
+            else
+            {
+                PXBaseUri = new Uri(fullBaseUrl);
+            }
+
+            // Dependencies need to selfhost before px, we need to reserve px
+            // port so other dependencies don't take it.
+            PreRegisteredPorts.Add(PXBaseUri.Port);
+
+
+            // No-op: All dependencies are configured in ConfigureServices above.
+            var selfhostServices = new[]
+            {
+                typeof(PIMSAccessor),
+                typeof(AccountServiceAccessor),
+                typeof(CatalogServiceAccessor),
+                typeof(PayerAuthServiceAccessor),
+                typeof(PurchaseServiceAccessor),
+                typeof(StoredValueAccessor),
+                typeof(TransactionServiceAccessor),
+                typeof(MSRewardsServiceAccessor),
+                typeof(TokenPolicyServiceAccessor),
+                typeof(PartnerSettingsServiceAccessor),
+                typeof(IssuerServiceAccessor),
+                typeof(WalletServiceAccessor),
+                typeof(TransactionDataService),
+                typeof(ChallengeManagementService),
+                typeof(RiskServiceAccessor),
+                typeof(PaymentOrchestratorService),
+                typeof(FraudDetectionService)
+            };
+
+            var selfHostedDependencies = new Dictionary<Type, HostableService>();
+
+            HostableService? dependencyEmulatorService = null;
+
+            // Create a single shared configuration action
+            Action<WebApplicationBuilder> configAction = b => Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.WebApiConfig.Register(b);
+
+            try
+            {
+                dependencyEmulatorService = new HostableService(configAction, Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.WebApiConfig.ConfigureRoutes, PXBaseUri);
+            }
+            catch
+            {
+                // Retry once just like the old code did
+                try
+                {
+                    dependencyEmulatorService = new HostableService(configAction, Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.WebApiConfig.ConfigureRoutes, PXBaseUri);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to initialize DependencyEmulators. Error: {ex}");
+                }
+            }
+
+            if (dependencyEmulatorService != null)
+            {
+                foreach (var selfhostService in selfhostServices)
+                {
+                    var serviceName = GetServiceName(selfhostService.FullName!);
+                    Console.WriteLine($"{serviceName} initialized as self hosted emulator service on {dependencyEmulatorService.BaseUri}");
+                    selfHostedDependencies[selfhostService] = dependencyEmulatorService;
+                }
+            }
+
+            return selfHostedDependencies;
+        }
+
+        public void ResetDependencies()
+        {
+            // Reset stateful testing hooks (if registered)
+            PXHandler?.ResetToDefault();
+            PXFlightHandler?.ResetToDefault();
+
+            // Reset dependency accessors
+            PXSettings.PartnerSettingsService.ResetToDefaults();
+            PXSettings.AccountsService.ResetToDefaults();
+            PXSettings.PayerAuthService.ResetToDefaults();
+            PXSettings.PimsService.ResetToDefaults();
+            PXSettings.SessionService.ResetToDefaults();
+            PXSettings.RiskService.ResetToDefaults();
+            PXSettings.TaxIdService.ResetToDefaults();
+            PXSettings.OrchestrationService.ResetToDefaults();
+            PXSettings.HIPService.ResetToDefaults();
+            PXSettings.WalletService.ResetToDefaults();
+            PXSettings.TransactionService.ResetToDefaults();
+            PXSettings.MSRewardsService.ResetToDefaults();
+            PXSettings.TokenPolicyService.ResetToDefaults();
+            PXSettings.TokenizationService.ResetToDefaults();
+        }
+
+        private static string GetServiceName(string serviceFullName)
+        {
+            return serviceFullName
+                .Split('.')
+                .Last()
+                .Replace("Accessor", "Service")
+                .Replace("ServiceService", "Service");
         }
     }
 }
-

--- a/net8/migration/SelfHostedPXServiceCore/SelfHostedBootstrap.cs
+++ b/net8/migration/SelfHostedPXServiceCore/SelfHostedBootstrap.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Commerce.Payments.PXService;
 using Microsoft.Commerce.Payments.PXService.Settings;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace SelfHostedPXServiceCore
 {
@@ -20,9 +21,13 @@ namespace SelfHostedPXServiceCore
             bool useSelfHostedDependencies,
             bool useArrangedResponses)
         {
-            PXServiceSettings settings = new Mocks.PXServiceSettings(
+            var settings = new Mocks.PXServiceSettings(
                 useSelfHostedDependencies ? new Dictionary<Type, HostableService>() : null,
                 useArrangedResponses);
+
+            // Register the concrete mock settings so tests can resolve the type directly.
+            // WebApiConfig.Register will also register the base PXServiceSettings type.
+            builder.Services.AddSingleton(settings);
 
             WebApiConfig.Register(builder, settings);
         }

--- a/net8/migration/SelfHostedPXServiceCore/SelfHostedBootstrap.cs
+++ b/net8/migration/SelfHostedPXServiceCore/SelfHostedBootstrap.cs
@@ -18,11 +18,11 @@ namespace SelfHostedPXServiceCore
         /// </summary>
         public static void ConfigureServices(
             WebApplicationBuilder builder,
-            bool useSelfHostedDependencies,
+            Dictionary<Type, HostableService>? selfHostedDependencies,
             bool useArrangedResponses)
         {
             var settings = new Mocks.PXServiceSettings(
-                useSelfHostedDependencies ? new Dictionary<Type, HostableService>() : null,
+                selfHostedDependencies,
                 useArrangedResponses);
 
             // Register the concrete mock settings so tests can resolve the type directly.

--- a/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
@@ -3,8 +3,29 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Commerce.Payments.PXService;
 using Microsoft.Commerce.Payments.PXService.Settings;
+using Microsoft.Commerce.Payments.PXService.RiskService.V7;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+
+using OrchestrationServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.OrchestrationService.OrchestrationServiceAccessor;
+using PayerAuthServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.PayerAuthService.PayerAuthServiceAccessor;
+using PurchaseServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.PurchaseService.PurchaseServiceAccessor;
+using StoredValueAccessor = Microsoft.Commerce.Payments.PXService.Accessors.StoredValue.StoredValueAccessor;
+using SellerMarketPlaceServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.SellerMarketPlaceService.SellerMarketPlaceServiceAccessor;
+using PaymentThirdPartyServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.PaymentThirdPartyService.PaymentThirdPartyServiceAccessor;
+using PartnerSettingsServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.PartnerSettingsService.PartnerSettingsServiceAccessor;
+using IssuerServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.IssuerService.IssuerServiceAccessor;
+using ChallengeManagementServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.ChallengeManagementService.ChallengeManagementServiceAccessor;
+using WalletServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.WalletService.WalletServiceAccessor;
+using TransactionDataServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.TransactionDataService.TransactionDataServiceAccessor;
+using MSRewardsServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.MSRewardsService.MSRewardsServiceAccessor;
+using TokenPolicyServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.TokenPolicyService.TokenPolicyServiceAccessor;
+using TokenizationServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.TokenizationService.TokenizationServiceAccessor;
+using PaymentOrchestratorServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.PaymentOrchestratorService.PaymentOrchestratorServiceAccessor;
+using FraudDetectionServiceAccessor = Microsoft.Commerce.Payments.PXService.Accessors.FraudDetectionService.FraudDetectionServiceAccessor;
+using AddressEnrichmentServiceAccessor = Microsoft.Commerce.Payments.PXService.AddressEnrichmentService.V7.AddressEnrichmentServiceAccessor;
 
 namespace SelfHostedPXServiceCore
 {
@@ -18,6 +39,9 @@ namespace SelfHostedPXServiceCore
     {
         /// <summary>Wrapper around the ASP.NET Core host.</summary>
         public static HostableService PxHostableService { get; private set; } = default!;
+
+        /// <summary>Dependency emulator hosts keyed by accessor type.</summary>
+        public static Dictionary<Type, HostableService> SelfHostedDependencies { get; private set; } = new();
 
         /// <summary>PX service settings registered with the host.</summary>
         public static PXServiceSettings PXSettings { get; private set; } = default!;
@@ -50,11 +74,15 @@ namespace SelfHostedPXServiceCore
                 ? new Uri("http://localhost")
                 : new Uri(baseUrl);
 
+            var dependencies = useSelfHostedDependencies
+                ? ConfigureDependencies(baseUri)
+                : null;
+
             PxHostableService = new HostableService(
                 builder =>
                 {
                     // Register PX controllers/services
-                    SelfHostedBootstrap.ConfigureServices(builder, useSelfHostedDependencies, useArrangedResponses);
+                    SelfHostedBootstrap.ConfigureServices(builder, dependencies, useArrangedResponses);
 
                     // Middlewares exposed as testing hooks
                     builder.Services.AddSingleton<PXServiceHandler>();
@@ -77,6 +105,7 @@ namespace SelfHostedPXServiceCore
             PXHandler = PxHostableService.App.Services.GetRequiredService<PXServiceHandler>();
             PXFlightHandler = PxHostableService.App.Services.GetRequiredService<PXServiceFlightHandler>();
             PXCorsHandler = PxHostableService.App.Services.GetService<PXServiceCorsHandler>();
+            SelfHostedDependencies = dependencies ?? new Dictionary<Type, HostableService>();
 
             return new SelfHostedPxService();
         }
@@ -110,6 +139,90 @@ namespace SelfHostedPXServiceCore
             PXSettings.MSRewardsService.ResetToDefaults();
             PXSettings.TokenPolicyService.ResetToDefaults();
             PXSettings.TokenizationService.ResetToDefaults();
+        }
+
+        private static Dictionary<Type, HostableService> ConfigureDependencies(Uri baseUri)
+        {
+            var selfhostServices = new[]
+            {
+                typeof(PIMSAccessor),
+                typeof(OrchestrationServiceAccessor),
+                typeof(AccountServiceAccessor),
+                typeof(PayerAuthServiceAccessor),
+                typeof(PurchaseServiceAccessor),
+                typeof(CatalogServiceAccessor),
+                typeof(SessionServiceAccessor),
+                typeof(StoredValueAccessor),
+                typeof(RiskServiceAccessor),
+                typeof(TaxIdServiceAccessor),
+                typeof(AddressEnrichmentServiceAccessor),
+                typeof(TransactionServiceAccessor),
+                typeof(SellerMarketPlaceServiceAccessor),
+                typeof(PaymentThirdPartyServiceAccessor),
+                typeof(AzureExPAccessor),
+                typeof(PartnerSettingsServiceAccessor),
+                typeof(IssuerServiceAccessor),
+                typeof(ChallengeManagementServiceAccessor),
+                typeof(WalletServiceAccessor),
+                typeof(TransactionDataServiceAccessor),
+                typeof(MSRewardsServiceAccessor),
+                typeof(TokenPolicyServiceAccessor),
+                typeof(TokenizationServiceAccessor),
+                typeof(PaymentOrchestratorServiceAccessor),
+                typeof(FraudDetectionServiceAccessor)
+            };
+
+            var selfHostedDependencies = new Dictionary<Type, HostableService>();
+
+            HostableService? dependencyEmulatorService = null;
+
+            Action<WebApplicationBuilder> configAction = b =>
+                Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.WebApiConfig.Register(b);
+
+            try
+            {
+                dependencyEmulatorService = new HostableService(
+                    configAction,
+                    _ => { },
+                    baseUri,
+                    Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.WebApiConfig.ConfigureRoutes);
+            }
+            catch
+            {
+                try
+                {
+                    dependencyEmulatorService = new HostableService(
+                        configAction,
+                        _ => { },
+                        baseUri,
+                        Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.WebApiConfig.ConfigureRoutes);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to initialize DependencyEmulators. Error: {ex}");
+                }
+            }
+
+            if (dependencyEmulatorService != null)
+            {
+                foreach (var svc in selfhostServices)
+                {
+                    var serviceName = GetServiceName(svc.FullName!);
+                    Console.WriteLine($"{serviceName} initialized as self hosted emulator service on {dependencyEmulatorService.BaseUri}");
+                    selfHostedDependencies[svc] = dependencyEmulatorService;
+                }
+            }
+
+            return selfHostedDependencies;
+        }
+
+        private static string GetServiceName(string serviceFullName)
+        {
+            return serviceFullName
+                .Split('.')
+                .Last()
+                .Replace("Accessor", "Service")
+                .Replace("ServiceService", "Service");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Register concrete `PXServiceSettings` mock with DI in self-hosted bootstrap
- Add dependency injection using directive

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abcc0ab09083298d562c2b90489392