### PR TITLE
Refactor self-hosted PX service for in-memory TestServer

### DIFF
--- a/net8/migration/SelfHostedPXServiceCore/HostableService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/HostableService.cs
@@ -22,6 +22,7 @@ namespace SelfHostedPXServiceCore
     {
         public Uri BaseUri { get; private set; } = default!;
         public HttpClient HttpSelfHttpClient { get; private set; } = default!;
+        public HttpClient Client => HttpSelfHttpClient;
         public WebApplication App { get; private set; } = default!;
 
         /// <summary>
@@ -101,6 +102,7 @@ namespace SelfHostedPXServiceCore
         public void Dispose()
         {
             try { App?.StopAsync().GetAwaiter().GetResult(); } catch { }
+            try { App?.DisposeAsync().AsTask().GetAwaiter().GetResult(); } catch { }
             try { HttpSelfHttpClient?.Dispose(); } catch { }
         }
     }

--- a/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
@@ -39,6 +39,7 @@ namespace SelfHostedPXServiceCore
 
         /// <summary>HttpClient wired to the in-memory PX service.</summary>
         public HttpClient HttpSelfHttpClient { get; private set; } = default!;
+        public HttpClient Client => HttpSelfHttpClient;
 
         public IHost SelfHost = default!;
 
@@ -104,7 +105,7 @@ namespace SelfHostedPXServiceCore
         {
             try { HttpSelfHttpClient?.Dispose(); } catch { }
             try { SelfHost?.Dispose(); } catch { }
-
+            try { PxHostableService?.Dispose(); } catch { }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- run PX self-host entirely in memory using TestServer
- expose HttpClient aliases and ensure proper disposal
- clarify Program entry point and use `using` when spinning up SelfHostedPxService

## Testing
- `dotnet build net8/migration/SelfHostedPXService/SelfHostedPXService.csproj --no-dependencies` *(fails: The imported project "/msbuild/Environment.props" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc0c392e083299b9cec5e2cd630f3