### PR TITLE
Use TestServer for PX service tests and add endpoint diagnostics

### DIFF
--- a/net8/migration/CIT.PXService/Tests/TestBase.cs
+++ b/net8/migration/CIT.PXService/Tests/TestBase.cs
@@ -45,6 +45,8 @@ namespace CIT.PXService.Tests
         [AssemblyInitialize]
         public static void Initialize(TestContext context)
         {
+            // Spin up the PX service in-memory using TestServer so tests can issue HTTP
+            // requests without opening real network sockets.
             SelfHostedPxService = SelfHostedPxService.StartInMemory(null, false, true);
             PXHandler = SelfHostedPxService.PXHandler;
             PXSettings = SelfHostedPxService.PXSettings;
@@ -53,6 +55,11 @@ namespace CIT.PXService.Tests
             PXBaseUri = SelfHostedPxService.PxHostableService.BaseUri;
             PXCorsHandler = SelfHostedPxService.PXCorsHandler;
             PXFlightHandler = SelfHostedPxService.PXFlightHandler;
+
+            // Verify routing is configured – if this fails the console output from
+            // HostableService will show which endpoint could not be resolved.
+            var probeResponse = PXClient.GetAsync(GetPXServiceUrl("/probe")).GetAwaiter().GetResult();
+            Assert.AreEqual(HttpStatusCode.OK, probeResponse.StatusCode, "PX probe endpoint is unreachable");
         }
 
         [TestCleanup]

--- a/net8/migration/CIT.PXService/Tests/TestBase.cs
+++ b/net8/migration/CIT.PXService/Tests/TestBase.cs
@@ -58,7 +58,7 @@ namespace CIT.PXService.Tests
 
             // Verify routing is configured – if this fails the console output from
             // HostableService will show which endpoint could not be resolved.
-            var probeResponse = PXClient.GetAsync(GetPXServiceUrl("/probe")).GetAwaiter().GetResult();
+            var probeResponse = PXClient.GetAsync(GetPXServiceUrl("/v7.0/probe")).GetAwaiter().GetResult();
             Assert.AreEqual(HttpStatusCode.OK, probeResponse.StatusCode, "PX probe endpoint is unreachable");
         }
 

--- a/net8/migration/PXService/GlobalConstants.cs
+++ b/net8/migration/PXService/GlobalConstants.cs
@@ -414,6 +414,7 @@ namespace Microsoft.Commerce.Payments.PXService
         public static class EndPointNames
         {
             public const string V7Probe = "probe";
+            public const string V7ProbeVersioned = "{version}/probe";
             public const string V7GetPaymentInstrumentEx = "{version}/{accountId}/paymentInstrumentsEx/{piid}";
             public const string V7ListPaymentInstrumentEx = "{version}/{accountId}/paymentInstrumentsEx";
             public const string V7GetChallengeContextPaymentInstrumentEx = "{version}/{accountId}/paymentInstrumentsEx/{piid}/getChallengeContext";

--- a/net8/migration/PXService/PXServiceAuthorizationFilterAttribute.cs
+++ b/net8/migration/PXService/PXServiceAuthorizationFilterAttribute.cs
@@ -104,7 +104,22 @@ namespace Microsoft.Commerce.Payments.PXService
 
         private static bool IsProbeUri(PathString path)
         {
-            return path.HasValue && path.Value.TrimStart('/').Equals(GlobalConstants.EndPointNames.V7Probe, StringComparison.OrdinalIgnoreCase);
+            if (!path.HasValue)
+            {
+                return false;
+            }
+
+            var trimmed = path.Value.TrimStart('/');
+
+            if (trimmed.Equals(GlobalConstants.EndPointNames.V7Probe, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var segments = trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            return segments.Length == 2
+                && segments[1].Equals(GlobalConstants.EndPointNames.V7Probe, StringComparison.OrdinalIgnoreCase)
+                && segments[0].StartsWith("v", StringComparison.OrdinalIgnoreCase);
         }
 
         private UserInformation AuthenticateByCert(HttpContext httpContext)

--- a/net8/migration/PXService/WebApiConfig.cs
+++ b/net8/migration/PXService/WebApiConfig.cs
@@ -27,7 +27,14 @@ namespace Microsoft.Commerce.Payments.PXService
         public static void Register(WebApplicationBuilder builder, PXServiceSettings settings)
         {
             builder.Services.AddSingleton(settings);
-            builder.Services.AddControllers()
+            builder.Services.AddControllers(options =>
+            {
+                options.Filters.Add(new PXServiceExceptionFilter());
+                if (settings.AuthorizationFilter != null)
+                {
+                    options.Filters.Add(settings.AuthorizationFilter);
+                }
+            })
                 .AddNewtonsoftJson(options =>
                 {
                     options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;

--- a/net8/migration/PXService/WebApiConfig.cs
+++ b/net8/migration/PXService/WebApiConfig.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Commerce.Payments.PXService
                     options.Filters.Add(settings.AuthorizationFilter);
                 }
             })
+                .AddApplicationPart(typeof(WebApiConfig).Assembly)
                 .AddNewtonsoftJson(options =>
                 {
                     options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;

--- a/net8/migration/PXService/WebApiConfig.cs
+++ b/net8/migration/PXService/WebApiConfig.cs
@@ -69,6 +69,11 @@ namespace Microsoft.Commerce.Payments.PXService
         {
             endpoints.MapControllerRoute(
                name: GlobalConstants.V7RouteNames.Probe,
+               pattern: GlobalConstants.EndPointNames.V7ProbeVersioned,
+               defaults: new { controller = C(GlobalConstants.ControllerNames.ProbeController), action = "Get" });
+
+            endpoints.MapControllerRoute(
+               name: GlobalConstants.V7RouteNames.Probe + "NoVersion",
                pattern: GlobalConstants.EndPointNames.V7Probe,
                defaults: new { controller = C(GlobalConstants.ControllerNames.ProbeController), action = "Get" });
 

--- a/net8/migration/SelfHostedPXServiceCore/HostableService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/HostableService.cs
@@ -95,13 +95,10 @@ namespace SelfHostedPXServiceCore
             // the selected endpoint is invoked.
             configureApp?.Invoke(App);
 
-            // Map routes + controllers after routing has been added so HttpContext.GetEndpoint()
+            // Map routes + controllers using top-level registration so HttpContext.GetEndpoint()
             // returns the matched endpoint during the middleware above.
-            App.UseEndpoints(endpoints =>
-            {
-                configureEndpoints?.Invoke(endpoints);
-                endpoints.MapControllers();
-            });
+            configureEndpoints?.Invoke(App);
+            App.MapControllers();
 
             // Start server
             App.Start();

--- a/net8/migration/SelfHostedPXServiceCore/HostableService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/HostableService.cs
@@ -31,7 +31,7 @@ namespace SelfHostedPXServiceCore
         /// <param name="configureApp">Configure middleware/endpoints. <c>MapControllers()</c> is already called.</param>
         /// <param name="fullBaseUrl">e.g. "http://localhost:49152". If null/empty a free port is chosen.</param>
         public HostableService(Action<WebApplication> configureApp, Uri fullBaseUrl)
-            : this(_ => { }, configureApp, fullBaseUrl)
+            : this(_ => { }, null, configureApp, fullBaseUrl)
         {
         }
 
@@ -39,12 +39,15 @@ namespace SelfHostedPXServiceCore
         /// Build + start a host with service configuration and app configuration callbacks.
         /// </summary>
         /// <param name="configureServices">Add DI/services. Controllers + Newtonsoft JSON are already registered.</param>
-        /// <param name="configureApp">Configure middleware/endpoints. A routing pipeline is already wired so that
-        /// middlewares added here run <em>after</em> <c>UseRouting()</c> but before endpoints are mapped.</param>
+        /// <param name="configureBeforeRouting">Configure middleware that must run <em>before</em> routing executes
+        /// (e.g. URL rewriters).</param>
+        /// <param name="configureApp">Configure middleware that runs <em>after</em> routing but before endpoints are
+        /// invoked.</param>
         /// <param name="fullBaseUrl">e.g. "http://localhost:49152". If null/empty a free port is chosen.</param>
         public HostableService(
             Action<WebApplicationBuilder> configureServices,
-            Action<WebApplication> configureApp,
+            Action<WebApplication>? configureBeforeRouting,
+            Action<WebApplication>? configureApp,
             Uri baseUri,
             Action<IEndpointRouteBuilder>? configureEndpoints = null)
         {
@@ -69,13 +72,12 @@ namespace SelfHostedPXServiceCore
 
             App = builder.Build();
 
-            // Ensure the routing matcher runs before custom middleware so HttpContext.GetEndpoint()
-            // is populated when those middlewares execute.
-            App.UseRouting();
+            // Allow callers to register middleware that needs to run before routing (e.g. to mutate
+            // the request path used for endpoint matching).
+            configureBeforeRouting?.Invoke(App);
 
-            // Callers can add middlewares, filters, etc. They will execute after routing but before
-            // the selected endpoint is invoked.
-            configureApp?.Invoke(App);
+            // Wire up routing so the endpoint matcher runs before custom post-routing middleware.
+            App.UseRouting();
 
             // Log which endpoint was selected for each request to aid in debugging tests.
             App.Use(async (ctx, next) =>
@@ -88,6 +90,10 @@ namespace SelfHostedPXServiceCore
                 }
                 await next();
             });
+
+            // Callers can add middlewares, filters, etc. They will execute after routing but before
+            // the selected endpoint is invoked.
+            configureApp?.Invoke(App);
 
             // Map routes + controllers after routing has been added so HttpContext.GetEndpoint()
             // returns the matched endpoint during the middleware above.

--- a/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
@@ -76,11 +76,11 @@ namespace SelfHostedPXServiceCore
 
             var pxHost = new HostableService(
                 b => WebApiConfig.Register(b, PXSettings),
-                app =>
+                configureBeforeRouting: null,
+                configureApp: app =>
                 {
                     app.UseMiddleware<PXServiceApiVersionHandler>();
                 },
-                configureApp: null,
                 baseUri: PXBaseUri,
                 configureEndpoints: WebApiConfig.AddUrlVersionedRoutes);
 

--- a/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
@@ -80,8 +80,9 @@ namespace SelfHostedPXServiceCore
                 {
                     app.UseMiddleware<PXServiceApiVersionHandler>();
                 },
-                PXBaseUri,
-                WebApiConfig.AddUrlVersionedRoutes);
+                configureApp: null,
+                baseUri: PXBaseUri,
+                configureEndpoints: WebApiConfig.AddUrlVersionedRoutes);
 
             PxHostableService = pxHost;
 
@@ -184,14 +185,22 @@ namespace SelfHostedPXServiceCore
 
             try
             {
-                dependencyEmulatorService = new HostableService(configAction, Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.WebApiConfig.ConfigureRoutes, PXBaseUri);
+                dependencyEmulatorService = new HostableService(
+                    configAction,
+                    configureBeforeRouting: null,
+                    configureApp: Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.WebApiConfig.ConfigureRoutes,
+                    baseUri: PXBaseUri);
             }
             catch
             {
                 // Retry once just like the old code did
                 try
                 {
-                    dependencyEmulatorService = new HostableService(configAction, Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.WebApiConfig.ConfigureRoutes, PXBaseUri);
+                    dependencyEmulatorService = new HostableService(
+                        configAction,
+                        configureBeforeRouting: null,
+                        configureApp: Microsoft.Commerce.Payments.Tests.Emulators.PXDependencyEmulators.WebApiConfig.ConfigureRoutes,
+                        baseUri: PXBaseUri);
                 }
                 catch (Exception ex)
                 {

--- a/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
+++ b/net8/migration/SelfHostedPXServiceCore/SelfHostedPxService.cs
@@ -76,11 +76,11 @@ namespace SelfHostedPXServiceCore
 
             var pxHost = new HostableService(
                 b => WebApiConfig.Register(b, PXSettings),
-                configureBeforeRouting: null,
-                configureApp: app =>
+                configureBeforeRouting: app =>
                 {
                     app.UseMiddleware<PXServiceApiVersionHandler>();
                 },
+                configureApp: null,
                 baseUri: PXBaseUri,
                 configureEndpoints: WebApiConfig.AddUrlVersionedRoutes);
 


### PR DESCRIPTION
## Summary
- ensure HostableService uses routing + endpoints so HttpContext.GetEndpoint() is populated
- start PX service tests on TestServer and assert probe endpoint

## Testing
- `dotnet build net8/migration/CIT.PXService/CIT.PXService.csproj` *(fails: 'Constants' is inaccessible, 'PIDLResource' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad52890d888329961ea3880c986122