### PR TITLE
Replace HttpRequestMessage.Properties with Options

### DIFF
--- a/net8/migration/CIT.PXService/HttpRequestMessageExtensions.cs
+++ b/net8/migration/CIT.PXService/HttpRequestMessageExtensions.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace System.Net.Http
+{
+    public static class HttpRequestMessageExtensions
+    {
+        private static readonly HttpRequestOptionsKey<IDictionary<string, object?>> PropertiesKey =
+            new("PX.Properties");
+
+        public static IDictionary<string, object?> GetProperties(this HttpRequestMessage request)
+        {
+            if (!request.Options.TryGetValue(PropertiesKey, out var properties))
+            {
+                properties = new Dictionary<string, object?>();
+                request.Options.Set(PropertiesKey, properties);
+            }
+
+            return properties;
+        }
+    }
+}

--- a/net8/migration/CIT.PXService/Tests/FlightingTests.cs
+++ b/net8/migration/CIT.PXService/Tests/FlightingTests.cs
@@ -22,7 +22,7 @@ namespace CIT.PXService.Tests
             Dictionary<string, string> actualFlightContext = null;
             PXHandler.PreProcess = (request) =>
             {
-                actualFlightContext = request.Properties["PX.FlightContext"] as Dictionary<string, string>;
+                actualFlightContext = request.GetProperties()["PX.FlightContext"] as Dictionary<string, string>;
             };
 
             // Act
@@ -51,7 +51,7 @@ namespace CIT.PXService.Tests
             Dictionary<string, string> actualFlightContext = null;
             PXHandler.PreProcess = (request) =>
             {
-                actualFlightContext = request.Properties["PX.FlightContext"] as Dictionary<string, string>;
+                actualFlightContext = request.GetProperties()["PX.FlightContext"] as Dictionary<string, string>;
             };
 
             // Act
@@ -91,7 +91,7 @@ namespace CIT.PXService.Tests
             Dictionary<string, string> actualFlightContext = null;
             PXHandler.PreProcess = (request) =>
             {
-                actualFlightContext = request.Properties["PX.FlightContext"] as Dictionary<string, string>;
+                actualFlightContext = request.GetProperties()["PX.FlightContext"] as Dictionary<string, string>;
             };
 
             // Act
@@ -131,7 +131,7 @@ namespace CIT.PXService.Tests
             Dictionary<string, string> actualFlightContext = null;
             PXHandler.PreProcess = (request) =>
             {
-                actualFlightContext = request.Properties["PX.FlightContext"] as Dictionary<string, string>;
+                actualFlightContext = request.GetProperties()["PX.FlightContext"] as Dictionary<string, string>;
             };
 
             // Act
@@ -166,7 +166,7 @@ namespace CIT.PXService.Tests
             Dictionary<string, string> actualFlightContext = null;
             PXHandler.PreProcess = (request) =>
             {
-                actualFlightContext = request.Properties["PX.FlightContext"] as Dictionary<string, string>;
+                actualFlightContext = request.GetProperties()["PX.FlightContext"] as Dictionary<string, string>;
             };
 
             // Act

--- a/net8/migration/CIT.PXService/Tests/GuestAccountHelperTests.cs
+++ b/net8/migration/CIT.PXService/Tests/GuestAccountHelperTests.cs
@@ -20,18 +20,18 @@ namespace CIT.PXService.Tests
 
             bool isGuestAccount = GuestAccountHelper.IsGuestAccount(request);
             Assert.IsTrue(isGuestAccount);
-            Assert.AreEqual(request.Properties["x-ms-customer_customerType"], CustomerType.AnonymousUser);
+            Assert.AreEqual(request.GetProperties()["x-ms-customer_customerType"], CustomerType.AnonymousUser);
         }
 
         [TestMethod]
         public void Test_IsGuestAccount_FromRequestProperties()
         {
             HttpRequestMessage request = new HttpRequestMessage();
-            request.Properties["x-ms-customer_customerType"] = CustomerType.AnonymousUser;
+            request.GetProperties()["x-ms-customer_customerType"] = CustomerType.AnonymousUser;
 
             bool isGuestAccount = GuestAccountHelper.IsGuestAccount(request);
             Assert.IsTrue(isGuestAccount);
-            Assert.AreEqual(request.Properties["x-ms-customer_customerType"], CustomerType.AnonymousUser);
+            Assert.AreEqual(request.GetProperties()["x-ms-customer_customerType"], CustomerType.AnonymousUser);
         }
     }
 }

--- a/net8/migration/CIT.PXService/Tests/PXServiceApiVersionHandlerTests.cs
+++ b/net8/migration/CIT.PXService/Tests/PXServiceApiVersionHandlerTests.cs
@@ -75,8 +75,8 @@ namespace CIT.PXService.Tests
             ApiVersion version = null;
             PXHandler.PreProcess = (request) =>
             {
-                versionKeyFound = request.Properties.ContainsKey(PaymentConstants.Web.Properties.Version);
-                versionObject = request.Properties[PaymentConstants.Web.Properties.Version];
+                versionKeyFound = request.GetProperties().ContainsKey(PaymentConstants.Web.Properties.Version);
+                versionObject = request.GetProperties()[PaymentConstants.Web.Properties.Version];
                 version = versionObject as ApiVersion;
             };
 
@@ -101,8 +101,8 @@ namespace CIT.PXService.Tests
             Dictionary<string, string> flightContext = null;
             PXHandler.PreProcess = (request) =>
             {
-                flightContextKeyFound = request.Properties.ContainsKey("PX.FlightContext");
-                flightContextObject = request.Properties["PX.FlightContext"];
+                flightContextKeyFound = request.GetProperties().ContainsKey("PX.FlightContext");
+                flightContextObject = request.GetProperties()["PX.FlightContext"];
                 flightContext = flightContextObject as Dictionary<string, string>;
             };
 
@@ -127,8 +127,8 @@ namespace CIT.PXService.Tests
             IEnumerable<KeyValuePair<string, string>> queryParams = null;
             PXHandler.PreProcess = (request) =>
             {
-                queryParamsKeyFound = request.Properties.ContainsKey("Payments.QueryParameters");
-                queryParamsObject = request.Properties["Payments.QueryParameters"];
+                queryParamsKeyFound = request.GetProperties().ContainsKey("Payments.QueryParameters");
+                queryParamsObject = request.GetProperties()["Payments.QueryParameters"];
                 queryParams = queryParamsObject as IEnumerable<KeyValuePair<string, string>>;
             };
 

--- a/net8/migration/CIT.PXService/Tests/PXServiceInputValidationHandlerTest.cs
+++ b/net8/migration/CIT.PXService/Tests/PXServiceInputValidationHandlerTest.cs
@@ -60,9 +60,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -110,9 +110,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -169,9 +169,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -229,9 +229,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -288,9 +288,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -338,9 +338,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -400,9 +400,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -448,9 +448,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -502,9 +502,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -554,9 +554,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -617,9 +617,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -675,9 +675,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -724,9 +724,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -776,9 +776,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -828,9 +828,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -890,9 +890,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -940,9 +940,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -996,9 +996,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -1044,9 +1044,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -1099,9 +1099,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -1153,9 +1153,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -1201,9 +1201,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -1249,9 +1249,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -1297,9 +1297,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 
@@ -1338,9 +1338,9 @@ namespace CIT.PXService.Tests
             bool didValidationSucceed = true;
             PXHandler.PreProcess = (request) =>
             {
-                if (request.Properties.ContainsKey("InputValidationFailed"))
+                if (request.GetProperties().ContainsKey("InputValidationFailed"))
                 {
-                    didValidationSucceed = !(bool)request.Properties["InputValidationFailed"];
+                    didValidationSucceed = !(bool)request.GetProperties()["InputValidationFailed"];
                 }
             };
 

--- a/net8/migration/CIT.PXService/Tests/PaymentInstrumentsExTests.cs
+++ b/net8/migration/CIT.PXService/Tests/PaymentInstrumentsExTests.cs
@@ -6775,9 +6775,9 @@ namespace CIT.PXService.Tests
 
             PXSettings.AccountsService.PreProcess = async (request) =>
             {
-                if (request.Method == HttpMethod.Get && request.Properties.ContainsKey(actionNameKey))
+                if (request.Method == HttpMethod.Get && request.GetProperties().ContainsKey(actionNameKey))
                 {
-                    if (string.Equals(request.Properties[actionNameKey].ToString(), "GetProfiles", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(request.GetProperties()[actionNameKey].ToString(), "GetProfiles", StringComparison.OrdinalIgnoreCase))
                     {
                         if (!pimsAssertCalled)
                         {
@@ -6786,7 +6786,7 @@ namespace CIT.PXService.Tests
                             Assert.IsFalse(getAddressByCountryAssertCalled);
                         }
                     }
-                    else if (string.Equals(request.Properties[actionNameKey].ToString(), "GetAddressByCountry", StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals(request.GetProperties()[actionNameKey].ToString(), "GetAddressByCountry", StringComparison.OrdinalIgnoreCase))
                     {
                         Assert.IsTrue(addressEnrichmentAssertCalled);
                         Assert.IsTrue(getProfilesAssertCalled);
@@ -6798,9 +6798,9 @@ namespace CIT.PXService.Tests
                         }
                     }
                 }
-                else if (request.Method == HttpMethod.Post && request.Properties.ContainsKey(actionNameKey))
+                else if (request.Method == HttpMethod.Post && request.GetProperties().ContainsKey(actionNameKey))
                 {
-                    if (string.Equals(request.Properties[actionNameKey].ToString(), "PostAddress", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(request.GetProperties()[actionNameKey].ToString(), "PostAddress", StringComparison.OrdinalIgnoreCase))
                     {
                         string requestContent = await request.Content.ReadAsStringAsync();
                         postAddressAssertCalled = true;
@@ -6808,7 +6808,7 @@ namespace CIT.PXService.Tests
                         Assert.IsTrue(getAddressByCountryAssertCalled);
                         Assert.IsFalse(updateProfileAssertCalled);
                     }
-                    else if (string.Equals(request.Properties[actionNameKey].ToString(), "UpdateProfile", StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals(request.GetProperties()[actionNameKey].ToString(), "UpdateProfile", StringComparison.OrdinalIgnoreCase))
                     {
                         Assert.IsTrue(postAddressAssertCalled);
                         updateProfileAssertCalled = true;
@@ -7465,7 +7465,7 @@ namespace CIT.PXService.Tests
 
             // Assert
             string resultContent = await result.Content.ReadAsStringAsync();
-            string instrumentManagementPropertyMessage = result.RequestMessage.Properties["InstrumentManagement.Message"].ToString();
+            string instrumentManagementPropertyMessage = result.RequestMessage.GetProperties()["InstrumentManagement.Message"].ToString();
             Assert.IsNotNull(instrumentManagementPropertyMessage);
             if (verifyJarvisAccountIdHmac)
             {

--- a/net8/migration/CIT.PXService/Tests/PaymentSessionsHandlerTests.cs
+++ b/net8/migration/CIT.PXService/Tests/PaymentSessionsHandlerTests.cs
@@ -1931,7 +1931,7 @@ namespace CIT.PXService.Tests
 
             PXSettings.PayerAuthService.PreProcess = (request) =>
             {
-                var authRequestContent = request.Properties["Payments.Content"] as Microsoft.Commerce.Payments.PXService.Model.PayerAuthService.AuthenticationRequest;
+                var authRequestContent = request.GetProperties()["Payments.Content"] as Microsoft.Commerce.Payments.PXService.Model.PayerAuthService.AuthenticationRequest;
                 Assert.AreEqual(authRequestContent.MessageVersion, expectedAuthReqMessageVersion, "Mismatch between expected AuthRequest Message Version");
             };
 
@@ -2012,7 +2012,7 @@ namespace CIT.PXService.Tests
             /// Act
             PXSettings.PayerAuthService.PreProcess = (request) =>
             {
-                var authRequestContent = request.Properties["Payments.Content"] as Microsoft.Commerce.Payments.PXService.Model.PayerAuthService.AuthenticationRequest;
+                var authRequestContent = request.GetProperties()["Payments.Content"] as Microsoft.Commerce.Payments.PXService.Model.PayerAuthService.AuthenticationRequest;
                 Assert.AreEqual(authRequestContent.MessageVersion, authReqMessageVersion, "Mismatch between expected AuthRequest Message Version");
             };
 

--- a/net8/migration/CIT.PXService/Tests/PaymentSessionsHandlerV2Tests.cs
+++ b/net8/migration/CIT.PXService/Tests/PaymentSessionsHandlerV2Tests.cs
@@ -2297,7 +2297,7 @@ namespace CIT.PXService.Tests
 
             PXSettings.PayerAuthService.PreProcess = (request) =>
             {
-                var authRequestContent = request.Properties["Payments.Content"] as Microsoft.Commerce.Payments.PXService.Model.PayerAuthService.AuthenticationRequest;
+                var authRequestContent = request.GetProperties()["Payments.Content"] as Microsoft.Commerce.Payments.PXService.Model.PayerAuthService.AuthenticationRequest;
                 Assert.AreEqual(authRequestContent.MessageVersion, expectedAuthReqMessageVersion, "Mismatch between expected AuthRequest Message Version");
             };
 
@@ -2378,7 +2378,7 @@ namespace CIT.PXService.Tests
             /// Act
             PXSettings.PayerAuthService.PreProcess = (request) =>
             {
-                var authRequestContent = request.Properties["Payments.Content"] as Microsoft.Commerce.Payments.PXService.Model.PayerAuthService.AuthenticationRequest;
+                var authRequestContent = request.GetProperties()["Payments.Content"] as Microsoft.Commerce.Payments.PXService.Model.PayerAuthService.AuthenticationRequest;
                 Assert.AreEqual(authRequestContent.MessageVersion, authReqMessageVersion, "Mismatch between expected AuthRequest Message Version");
             };
 

--- a/net8/migration/CIT.PXService/Tests/TestBase.cs
+++ b/net8/migration/CIT.PXService/Tests/TestBase.cs
@@ -84,7 +84,7 @@ namespace CIT.PXService.Tests
             {
                 PXHandler.PreProcess = (pxRequest) =>
                 {
-                    pxRequest.Properties[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] = flightFeatures == null ? new List<string>() : flightFeatures;
+                    pxRequest.GetProperties()[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] = flightFeatures == null ? new List<string>() : flightFeatures;
                 };
             }
 
@@ -101,7 +101,7 @@ namespace CIT.PXService.Tests
             {
                 PXHandler.PreProcess = (request) =>
                 {
-                    request.Properties[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] = string.IsNullOrEmpty(flightNames) ? new List<string>() : flightNames.Split(',').ToList<string>();
+                    request.GetProperties()[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] = string.IsNullOrEmpty(flightNames) ? new List<string>() : flightNames.Split(',').ToList<string>();
                 };
             }
 
@@ -144,7 +144,7 @@ namespace CIT.PXService.Tests
             List<string> enabledFeatures = null;
             PXHandler.PreProcess = (request) =>
             {
-                enabledFeatures = request.Properties[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] as List<string> ?? new List<string>();
+                enabledFeatures = request.GetProperties()[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] as List<string> ?? new List<string>();
                 foreach (string flightName in flightNames)
                 {
                     enabledFeatures.Add(flightName);
@@ -161,7 +161,7 @@ namespace CIT.PXService.Tests
         {
             PXHandler.PreProcess = (request) =>
             {
-                request.Properties[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] = string.IsNullOrEmpty(flightNames) ? new List<string>() : flightNames.Split(',').ToList<string>();
+                request.GetProperties()[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] = string.IsNullOrEmpty(flightNames) ? new List<string>() : flightNames.Split(',').ToList<string>();
             };
 
             var response = await PXClient.GetAsync(GetPXServiceUrl(url));
@@ -174,7 +174,7 @@ namespace CIT.PXService.Tests
         {
             PXHandler.PreProcess = (r) =>
             {
-                r.Properties[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] = string.IsNullOrEmpty(flightNames) ? new List<string>() : flightNames.Split(',').ToList<string>();
+                r.GetProperties()[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] = string.IsNullOrEmpty(flightNames) ? new List<string>() : flightNames.Split(',').ToList<string>();
             };
 
             var request = new HttpRequestMessage(method, url);
@@ -190,7 +190,7 @@ namespace CIT.PXService.Tests
         {
             PXHandler.PreProcess = (r) =>
             {
-                r.Properties[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] = string.IsNullOrEmpty(flightNames) ? new List<string>() : flightNames.Split(',').ToList<string>();
+                r.GetProperties()[PXService.GlobalConstants.RequestPropertyKeys.ExposedFlightFeatures] = string.IsNullOrEmpty(flightNames) ? new List<string>() : flightNames.Split(',').ToList<string>();
             };
 
             var request = new HttpRequestMessage(method, url);


### PR DESCRIPTION
## Summary
- avoid obsolete HttpRequestMessage.Properties by wrapping values in `HttpRequestMessage.Options`
- update tests to use `GetProperties()` helper

## Testing
- `dotnet test net8/migration/CIT.PXService/CIT.PXService.csproj` *(fails: PackageReference items Moq;Microsoft.Xbox.Experimentation.Contracts do not have corresponding PackageVersion)*

------
https://chatgpt.com/codex/tasks/task_e_68ae46a477e4832992d9d26ef7077d56