### PR TITLE
refactor: modernize net8 middleware

### DIFF
--- a/net8/migration/PXService/Program.cs
+++ b/net8/migration/PXService/Program.cs
@@ -28,7 +28,7 @@ WebApiConfig.Register(builder, pxSettings);
 // optional – if you rely on your own AI setup it’s fine to leave this
 builder.Services.AddApplicationInsightsTelemetry();
 
-var app = builder.Build();
+using var app = builder.Build();
 // Ensure the routing matcher runs before custom middleware so HttpContext.GetEndpoint()
 // is populated when those middlewares execute.
 app.UseRouting();
@@ -76,7 +76,7 @@ app.MapControllers();
 // graceful shutdown (replaces Global.asax Application_End)
 app.Lifetime.ApplicationStopping.Register(() => pxSettings?.AzureExPAccessor?.StopPolling());
 
-app.Run();
+await app.RunAsync();
 
 // -------- helpers --------
 static void EnsureSllInitialized()

--- a/net8/migration/PXService/V7/ProxyController.cs
+++ b/net8/migration/PXService/V7/ProxyController.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using System.Net.Http;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.DependencyInjection;
@@ -218,9 +219,15 @@ namespace Microsoft.Commerce.Payments.PXService.V7
             {
                 if (this.partnerSettings == null)
                 {
-                    object partnerSettingsObject = null;
-                    this.HttpContext.Items.TryGetValue(GlobalConstants.RequestPropertyKeys.PartnerSettings, out partnerSettingsObject);
-                    this.partnerSettings = partnerSettingsObject as PartnerSettings;
+                    var requestMessage = this.Request.ToHttpRequestMessage();
+                    if (requestMessage.TryGetProperty(GlobalConstants.RequestPropertyKeys.PartnerSettings, out PartnerSettings? settings))
+                    {
+                        this.partnerSettings = settings;
+                    }
+                    else if (this.HttpContext.Items.TryGetValue(GlobalConstants.RequestPropertyKeys.PartnerSettings, out var partnerSettingsObject))
+                    {
+                        this.partnerSettings = partnerSettingsObject as PartnerSettings;
+                    }
                 }
 
                 return this.partnerSettings;

--- a/net8/migration/PXService/WebApiConfig.cs
+++ b/net8/migration/PXService/WebApiConfig.cs
@@ -4,7 +4,6 @@ using Microsoft.Commerce.Payments.Common.Web;
 using Microsoft.Commerce.Payments.PXService.Settings;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Protocol.Handlers;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -26,7 +25,11 @@ namespace Microsoft.Commerce.Payments.PXService
         /// <param name="settings">PX service settings instance.</param>
         public static void Register(WebApplicationBuilder builder, PXServiceSettings settings)
         {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(settings);
+
             builder.Services.AddSingleton(settings);
+            builder.Services.AddRouting(options => options.LowercaseUrls = true);
             builder.Services.AddControllers(options =>
             {
                 options.Filters.Add(new PXServiceExceptionFilter());
@@ -52,8 +55,8 @@ namespace Microsoft.Commerce.Payments.PXService
             builder.Services.AddSingleton<PXServiceApiVersionHandler>(); // state used by CORS middleware
 
             string[] versionlessControllers = { GlobalConstants.ControllerNames.ProbeController };
-            builder.Services.AddSingleton(versionlessControllers);
-            builder.Services.AddSingleton<IDictionary<string, ApiVersion>>(sp =>
+            builder.Services.AddSingleton<IEnumerable<string>>(versionlessControllers);
+            builder.Services.AddSingleton<IReadOnlyDictionary<string, ApiVersion>>(sp =>
             {
                 var selectorInstance = sp.GetRequiredService<VersionedControllerSelector>();
                 return selectorInstance.SupportedVersions;


### PR DESCRIPTION
## Summary
- streamline trace correlation handler for null safety and reusable option copying
- tighten API version handler dependencies using immutable collections
- register routing and versioned controllers with safer service configuration
- run application with top-level async Main
- fetch partner settings from request options

## Testing
- `dotnet build net8/migration/PXService/PXService.csproj` *(fails: Unable to find package OpenTelemetry.Audit.Geneva and other internal packages)*

------
https://chatgpt.com/codex/tasks/task_e_68af84aadea483299a43595d639ce8c3