### PR TITLE
chore: migrate ShortURL controller to net8

### DIFF
--- a/net8/migration/PXService/V7/ShortURL/ShortURLController.cs
+++ b/net8/migration/PXService/V7/ShortURL/ShortURLController.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using System.Net.Http;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
-    using System.Web;
-    using System.Web.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Common.Web;
     using Microsoft.Commerce.Payments.PXService.Model.ShortURLDB;
     using OpenTelemetry.Trace;
 


### PR DESCRIPTION
## Summary
- replace System.Web references with ASP.NET Core MVC types
- leverage Common.Web extensions for response creation

## Testing
- `dotnet build net8/migration/PXService/PXService.csproj` *(fails: unable to restore packages such as OpenTelemetry.Audit.Geneva)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b17321fc8329a1c6ff5af95b9e46