### PR TITLE
Fix ambiguous route and settings smoke test

### DIFF
--- a/net8/migration/CIT.PXService/Tests/RoutingSmokeTests.cs
+++ b/net8/migration/CIT.PXService/Tests/RoutingSmokeTests.cs
@@ -33,7 +33,8 @@ namespace CIT.PXService.Tests
 
             foreach (var ep in endpoints)
             {
-                var pattern = "/" + ep.RoutePattern.RawText;
+                var rawPattern = ep.RoutePattern.RawText;
+                var pattern = "/" + rawPattern;
                 pattern = pattern.Replace("{version}", "v7.0", StringComparison.OrdinalIgnoreCase)
                                  .Replace("{accountId}", "acc")
                                  .Replace("{piid}", "pi")
@@ -41,9 +42,19 @@ namespace CIT.PXService.Tests
                                  .Replace("{challengeid}", "ch")
                                  .Replace("{paymentRequestId}", "pr")
                                  .Replace("{checkoutRequestId}", "cr")
-                                 .Replace("{sessionId}", "sid")
-                                 .Replace("{appName}", "app")
-                                 .Replace("{appVersion}", "1");
+                                 .Replace("{sessionId}", "sid");
+
+                if (rawPattern.Contains("{appName}", StringComparison.OrdinalIgnoreCase))
+                {
+                    pattern = pattern.Replace("{appName}", "Microsoft.MicrosoftWallet", StringComparison.OrdinalIgnoreCase)
+                                     .Replace("{appVersion}", "1");
+                }
+                else
+                {
+                    pattern = pattern.Replace("{appName}", "app", StringComparison.OrdinalIgnoreCase)
+                                     .Replace("{appVersion}", "1");
+                }
+
                 pattern = Regex.Replace(pattern, "{[^/]+}", "1");
 
                 var method = ep.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods?.FirstOrDefault() ?? HttpMethods.Get;

--- a/net8/migration/PXService/V7/PaymentChallenge/PaymentSessionDescriptionsController.cs
+++ b/net8/migration/PXService/V7/PaymentChallenge/PaymentSessionDescriptionsController.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
+    [NonController]
     public class PaymentSessionDescriptionsController : ProxyController
     {
         /// <summary>


### PR DESCRIPTION
## Summary
- mark PaymentChallenge `PaymentSessionDescriptionsController` as `[NonController]` to prevent duplicate routing
- use a valid app name in `RoutingSmokeTests` so the settings endpoint responds

## Testing
- `dotnet test net8/migration/CIT.PXService/CIT.PXService.csproj --no-build --filter "RoutingSmokeTests"` *(fails: imported project '/msbuild/Environment.props' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b8d24128832980cc55566751b9df