### PR TITLE
Allow addressId from query string

### DIFF
--- a/net8/migration/PXService/V7/Pidl/AddressDescriptionsController.cs
+++ b/net8/migration/PXService/V7/Pidl/AddressDescriptionsController.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Commerce.Payments.PXService.V7
             [FromQuery] string partner = Constants.ServiceDefaults.DefaultPartnerName,
             [FromQuery] string? scenario = null,
             [FromQuery] string? operation = null,
-            [FromRoute] string? addressId = null,
+            string? addressId = null,
             [FromQuery] bool avsSuggest = false,
             [FromQuery] bool setAsDefaultBilling = false)
         {


### PR DESCRIPTION
## Summary
- allow AddressDescriptionsController to read addressId from query string

## Testing
- `dotnet test net8/migration/CIT.PXService/CIT.PXService.csproj --filter "ValidateAddressPIDL_DefaultTemplate" --verbosity normal` *(fails: PackageReference items Moq;Microsoft.Xbox.Experimentation.Contracts do not have corresponding PackageVersion)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d4d91ef88329b9a2bf9475e6818a