### PR TITLE
Handle missing error logger in PXTraceCorrelationHandler

### DIFF
--- a/net8/migration/PXCommon/PXTraceCorrelationHandler.cs
+++ b/net8/migration/PXCommon/PXTraceCorrelationHandler.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Commerce.Payments.PXCommon
             }
             catch (Exception ex)
             {
-                this.LogError("PXTraceCorrelationHandler.TraceClientOperation: " + ex.Message, requestTraceId);
+                this.LogError?.Invoke("PXTraceCorrelationHandler.TraceClientOperation: " + ex.Message, requestTraceId);
             }
         }
 
@@ -342,7 +342,7 @@ namespace Microsoft.Commerce.Payments.PXCommon
             }
             catch (Exception ex)
             {
-                this.LogError("PXTraceCorrelationHandler.TraceClientOperation: " + ex.Message, requestTraceId);
+                this.LogError?.Invoke("PXTraceCorrelationHandler.TraceClientOperation: " + ex.Message, requestTraceId);
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure PXTraceCorrelationHandler safely invokes error logger

## Testing
- `dotnet build net8/migration/PXCommon/PXCommon.csproj -nologo` *(fails: Unable to find package Microsoft.IdentityModel.S2S)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a2976b0c8329a0d1c313d4541acc