### PR TITLE
Fix build references for PXService

### DIFF
--- a/net8/msbuild/Environment.props
+++ b/net8/msbuild/Environment.props
@@ -37,18 +37,18 @@
   
   <!-- team specific values-->
   <ItemGroup>
-    <NonTeamPrivateFolders Include="$(INETROOT)\Private\Shared;$(INETROOT)\Private\developer;$(INETROOT)\Private\_ReSharper.dirs" />
-    
-    <Teams Include="$([System.IO.Directory]::GetDirectories(`$(INETROOT)\Private`))" Exclude="@(NonTeamPrivateFolders)">
+    <NonTeamPrivateFolders Include="$(INETROOT)\private\Shared;$(INETROOT)\private\developer;$(INETROOT)\private\_ReSharper.dirs" />
+
+    <Teams Include="$([System.IO.Directory]::GetDirectories(`$(INETROOT)\private`))" Exclude="@(NonTeamPrivateFolders)">
       <IsCurrentTeam>$(MSBuildProjectFullPath.StartsWith(%(Identity)\, true, null))</IsCurrentTeam>
       <Name>%(Filename)</Name>
     </Teams>
   </ItemGroup>
   
   <PropertyGroup>
-     <SllTracingSdkPath>$(INETROOT)\Private\Shared\Library\Tracing\SllLogging</SllTracingSdkPath>
+     <SllTracingSdkPath>$(INETROOT)\private\Shared\Library\Tracing\SllLogging</SllTracingSdkPath>
      <!-- Derive the team name based on the path of the current project file e.g. d:\sd\depot\private\{team}\project\proj.csproj == {team} -->
-     <Private>$(INETROOT)\Private\</Private>
+     <Private>$(INETROOT)\private\</Private>
      <PrivateLength>$(Private.Length)</PrivateLength>
      <TeamEndIndex>$(MSBuildProjectFullPath.IndexOf(\, $(PrivateLength)))</TeamEndIndex>
      <TeamLength>$([MSBUILD]::Subtract($(TeamEndIndex), $(PrivateLength)))</TeamLength>
@@ -57,7 +57,7 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(TeamName)' != ''">
-     <TeamRoot>$(INETROOT)\Private\$(TeamName)</TeamRoot>
+     <TeamRoot>$(INETROOT)\private\$(TeamName)</TeamRoot>
 	 <DropRoot>$(INETROOT)\Drop\$(Configuration)</DropRoot>
      <ProjectDirRelativeToTeamDir>$(MSBuildProjectDirectory.Substring($(TeamRoot.Length)))</ProjectDirRelativeToTeamDir>
      <OutputPath>bin\$(Configuration)</OutputPath>

--- a/net8/private/Payments/PXService/PXService.csproj
+++ b/net8/private/Payments/PXService/PXService.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
@@ -52,13 +52,33 @@
                         <Private>true</Private>
                 </Reference>
                 <Reference Include="CertificateVerificationCore">
-                        <HintPath>..\..\nugets\net8.0\microsoft.commerce.payments.management.certificateverificationcore\1.3.34\lib\netstandard2.0\CertificateVerificationCore.dll</HintPath>
+                        <HintPath>..\..\nugets\net8.0\CertificateVerificationCore.dll</HintPath>
+                        <Private>true</Private>
+                </Reference>
+                <Reference Include="Microsoft.IdentityModel.S2S">
+                        <HintPath>..\..\nugets\net8.0\Microsoft.IdentityModel.S2S.dll</HintPath>
+                        <Private>true</Private>
+                </Reference>
+                <Reference Include="Microsoft.IdentityModel.S2S.Tokens">
+                        <HintPath>..\..\nugets\net8.0\Microsoft.IdentityModel.S2S.Tokens.dll</HintPath>
+                        <Private>true</Private>
+                </Reference>
+                <Reference Include="Microsoft.IdentityModel.S2S.Configuration">
+                        <HintPath>..\..\nugets\net8.0\Microsoft.IdentityModel.S2S.Configuration.dll</HintPath>
+                        <Private>true</Private>
+                </Reference>
+                <Reference Include="Microsoft.CommonSchema.Services">
+                        <HintPath>..\..\nugets\net8.0\Microsoft.CommonSchema.Services.dll</HintPath>
+                        <Private>true</Private>
+                </Reference>
+                <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
+                        <HintPath>..\..\nugets\net8.0\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>
                         <Private>true</Private>
                 </Reference>
         </ItemGroup>
 
-	<!-- Bring along the WCF configuration file at build time -->
-	<ItemGroup>
+        <!-- Bring along the WCF configuration file at build time -->
+        <ItemGroup>
 		<Content Update="wcf.config">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>

--- a/net8/private/Payments/PXService/SystemWebStubs.cs
+++ b/net8/private/Payments/PXService/SystemWebStubs.cs
@@ -1,0 +1,10 @@
+namespace System.Web
+{
+}
+
+namespace System.Web.Http
+{
+    public class ApiController
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- correct path casing in Environment.props
- reference missing PXService libraries and add stubs for System.Web.Http

## Testing
- `dotnet build net8/private/Payments/PXService/PXService.csproj` *(fails: ParameterValue assembly missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7697c6c8c83298bb6ac11a2add21d