### PR TITLE
Remove Bond references from PXService and dependent projects

### DIFF
--- a/net8/private/Payments/PXService/Accessors/NetworkTokenizationService/INetworkTokenizationServiceAccessor.cs
+++ b/net8/private/Payments/PXService/Accessors/NetworkTokenizationService/INetworkTokenizationServiceAccessor.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.NetworkTokenizationSer
 	using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.PimsModel.V4;
     using Microsoft.Commerce.Payments.PXService.Model.NetworkTokenizationService;
-    using Microsoft.Commerce.Tracing;
 
     public interface INetworkTokenizationServiceAccessor
     {

--- a/net8/private/Payments/PXService/Accessors/ShortURLDB/IShortURLDBAccessor.cs
+++ b/net8/private/Payments/PXService/Accessors/ShortURLDB/IShortURLDBAccessor.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Commerce.Payments.PXService.Accessors.ShortURLDB
     using System.Threading.Tasks;
     using Microsoft.Commerce.Payments.PXService.Model.ShortURLDB;
     using Microsoft.Commerce.Payments.PXService.Model.ShortURLService;
-    using Microsoft.Commerce.Tracing;
 
     public interface IShortURLDBAccessor
     {

--- a/net8/private/Payments/PXService/HttpRequestHelper.cs
+++ b/net8/private/Payments/PXService/HttpRequestHelper.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Commerce.Payments.PXService
     using Microsoft.Commerce.Payments.PXCommon;
     using Microsoft.Commerce.Payments.PXService.Model;
     using Microsoft.Commerce.Payments.PXService.V7.Contexts;
-    using Microsoft.Commerce.Tracing;
     using Microsoft.Extensions.Primitives;
     using Newtonsoft.Json;
     using System;

--- a/net8/private/Payments/PXService/PXServicePIDLValidationHandler.cs
+++ b/net8/private/Payments/PXService/PXServicePIDLValidationHandler.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Commerce.Payments.Common.Tracing;
 using Microsoft.Commerce.Payments.Common.Web;
 using Microsoft.Commerce.Payments.PXCommon;
-using Microsoft.Commerce.Tracing;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;

--- a/net8/private/Payments/PXService/Settings/PXServiceSettings.cs
+++ b/net8/private/Payments/PXService/Settings/PXServiceSettings.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Commerce.Payments.PXService.Settings
     using Microsoft.Commerce.Payments.PXService.Accessors.TokenPolicyService;
     using Microsoft.Commerce.Payments.PXService.Accessors.TransactionDataService;
     using Microsoft.Commerce.Payments.PXService.Settings.FeatureConfig;
-    using Microsoft.Commerce.Tracing;
     using Microsoft.Identity.Web;
     using Newtonsoft.Json;
     using RiskService.V7;

--- a/net8/private/Payments/PXService/V7/ExpressCheckoutController.cs
+++ b/net8/private/Payments/PXService/V7/ExpressCheckoutController.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using Microsoft.Commerce.Payments.PimsModel.V4;
     using Microsoft.Commerce.Payments.PXCommon;
     using Microsoft.Commerce.Payments.PXService.V7.PaymentClient;
-    using Microsoft.Commerce.Tracing;
     using Newtonsoft.Json;
     using static Microsoft.Commerce.Payments.PidlFactory.GlobalConstants.ServiceContextKeys;
     using PaymentInstrument = PimsModel.V4.PaymentInstrument;

--- a/net8/private/Payments/PXService/V7/GuestAccountHelper.cs
+++ b/net8/private/Payments/PXService/V7/GuestAccountHelper.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PXService.V7.Contexts;
-    using Microsoft.Commerce.Tracing;
     using Microsoft.Commerce.Payments.PXCommon;
     using System;
     using System.Net.Http;

--- a/net8/private/Payments/PXService/V7/PIHelper.cs
+++ b/net8/private/Payments/PXService/V7/PIHelper.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Commerce.Payments.PXService.V7
     using Microsoft.Commerce.Payments.PXService.Model.PXInternal;
     using Microsoft.Commerce.Payments.PXService.Settings;
     using Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge;
-    using Microsoft.Commerce.Tracing;
 
     internal static class PIHelper
     {

--- a/net8/private/Payments/PXService/V7/PaymentChallenge/PaymentSessionDescriptionsController.cs
+++ b/net8/private/Payments/PXService/V7/PaymentChallenge/PaymentSessionDescriptionsController.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Commerce.Payments.PXService.V7.PaymentChallenge
     using Microsoft.Commerce.Payments.PidlFactory.V7;
     using Microsoft.Commerce.Payments.PidlModel.V7;
     using Microsoft.Commerce.Payments.PXCommon;
-    using Microsoft.Commerce.Tracing;
     using Model;
     using Newtonsoft.Json;
     using System;

--- a/net8/private/Payments/PXService/Web.config
+++ b/net8/private/Payments/PXService/Web.config
@@ -102,14 +102,6 @@
         <bindingRedirect oldVersion="0.0.0.0-5.1.218.0" newVersion="5.1.218.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Bond.Attributes" publicKeyToken="87e9ead25a117286" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.100" newVersion="13.0.0.100" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Bond" publicKeyToken="87e9ead25a117286" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.100" newVersion="13.0.0.100" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Rest.ClientRuntime" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
@@ -180,10 +172,6 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Bond.IO" publicKeyToken="87e9ead25a117286" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.100" newVersion="13.0.0.100" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/net8/private/Payments/PXService/packages.config
+++ b/net8/private/Payments/PXService/packages.config
@@ -8,9 +8,6 @@
   <package id="Azure.Security.KeyVault.Secrets" version="4.6.0" targetFramework="net472" />
   <package id="Azure.Storage.Blobs" version="12.13.0" targetFramework="net472" />
   <package id="Azure.Storage.Common" version="12.12.0" targetFramework="net472" />
-  <package id="Bond.Core.CSharp" version="13.0.0" targetFramework="net472" />
-  <package id="Bond.CSharp" version="13.0.0" targetFramework="net472" />
-  <package id="Bond.Runtime.CSharp" version="13.0.0" targetFramework="net472" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights" version="2.12.0" targetFramework="net45" requireReinstallation="true" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net45" />
@@ -34,7 +31,6 @@
   <package id="Microsoft.Bcl.TimeProvider" version="8.0.1" targetFramework="net472" />
   <package id="Microsoft.Commerce.Payments.Authentication" version="0.0.9" targetFramework="net472" />
   <package id="Microsoft.Commerce.Payments.Management.CertificateVerificationCore" version="1.3.30" targetFramework="net472" />
-  <package id="Microsoft.CommonSchema.Bond" version="4.0.17341.1" targetFramework="net472" />
   <package id="Microsoft.CommonSchema.Services" version="5.1.218" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.4.1" targetFramework="net472" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net472" />
@@ -104,7 +100,6 @@
   <package id="Microsoft.Practices.EnterpriseLibrary.Validation" version="4.0.30319" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.24" targetFramework="net472" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.19" targetFramework="net472" />
-  <package id="Microsoft.VariantAssignment.Bond" version="4.1.227711" targetFramework="net472" />
   <package id="Microsoft.Win32.Registry" version="5.0.0" targetFramework="net472" />
   <package id="Ms.Qos" version="4.0.17341.1" targetFramework="net472" />
   <package id="Ms.Qos.IncomingServiceRequest" version="4.0.17341.1" targetFramework="net472" />

--- a/net8/private/Payments/PXService/readme.md
+++ b/net8/private/Payments/PXService/readme.md
@@ -104,11 +104,9 @@ Introduced a new Spin Operator for Correlation Vector.
             .LogSeqProcessStateCompleted(elapsed);
 ```
 ## Updated dependent packages
-    - Microsoft.CommonSchema.Bond v4.0.17331.1
     - Ms.Qos v4.0.17331.1
     - Ms.Qos.IncomingServiceRequest v4.0.17331.1
     - Ms.Qos.OutgoingServiceRequest v4.0.17331.1
-    - Bond.CSharp v7.0.1
     - NewtonSoft.Json v9.0.1
     - Microsoft.Diagnostics.Tracing.EventSource v1.1.28
 

--- a/net8/private/Payments/Pidl/PXCommon/PXCommon.csproj
+++ b/net8/private/Payments/Pidl/PXCommon/PXCommon.csproj
@@ -18,10 +18,6 @@
                         <HintPath>..\..\..\nugets\net8.0\Microsoft.CommonSchema.Services.dll</HintPath>
                         <Private>true</Private>
                 </Reference>
-                <Reference Include="Microsoft.CommonSchema.Bond">
-                        <HintPath>..\..\..\nugets\net8.0\Microsoft.CommonSchema.Bond.dll</HintPath>
-                        <Private>true</Private>
-                </Reference>
         </ItemGroup>
 
 	<ItemGroup>

--- a/net8/private/Payments/Pidl/PXCommon/PerformanceTracingScope.cs
+++ b/net8/private/Payments/Pidl/PXCommon/PerformanceTracingScope.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Commerce.Payments.PXCommon
     using System;
     using System.Diagnostics;
     using Microsoft.Commerce.Payments.Common.Tracing;
-    using Microsoft.Commerce.Tracing;
 
     /// <summary>
     /// Performance Instrumentation/Tracing class to log the performance of all the 
@@ -19,16 +18,12 @@ namespace Microsoft.Commerce.Payments.PXCommon
 
         private Stopwatch stopwatch = null;
         private string eventName;
-        private EventTraceActivity traceActivityId;
         private string perfEventCorrelationId;
-
-        public PerformanceTracingScope(string eventName, EventTraceActivity traceActivityId)
+        public PerformanceTracingScope(string eventName)
         {
             ArgumentValidator.EnsureNotNullOrWhitespace(eventName, "eventName");
-            ArgumentValidator.EnsureNotNull(traceActivityId, "eventTraceActivity");
 
             this.eventName = eventName;
-            this.traceActivityId = traceActivityId;
             this.StartTracing();
         }
 

--- a/net8/private/Payments/Pidl/PXCommon/app.config
+++ b/net8/private/Payments/Pidl/PXCommon/app.config
@@ -27,14 +27,6 @@
         <bindingRedirect oldVersion="0.0.0.0-5.1.218.0" newVersion="5.1.218.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Bond.Attributes" publicKeyToken="87e9ead25a117286" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.100" newVersion="13.0.0.100" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Bond" publicKeyToken="87e9ead25a117286" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.100" newVersion="13.0.0.100" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
       </dependentAssembly>

--- a/net8/private/Payments/Pidl/PXCommon/readme.md
+++ b/net8/private/Payments/Pidl/PXCommon/readme.md
@@ -104,11 +104,9 @@ Introduced a new Spin Operator for Correlation Vector.
             .LogSeqProcessStateCompleted(elapsed);
 ```
 ## Updated dependent packages
-    - Microsoft.CommonSchema.Bond v4.0.17331.1
     - Ms.Qos v4.0.17331.1
     - Ms.Qos.IncomingServiceRequest v4.0.17331.1
     - Ms.Qos.OutgoingServiceRequest v4.0.17331.1
-    - Bond.CSharp v7.0.1
     - NewtonSoft.Json v9.0.1
     - Microsoft.Diagnostics.Tracing.EventSource v1.1.28
 

--- a/net8/private/Payments/Pidl/PidlFactory/V7/PIDLFeatureProcess/Features/Add/UpdateStaticResourceServiceEndpoint.cs
+++ b/net8/private/Payments/Pidl/PidlFactory/V7/PIDLFeatureProcess/Features/Add/UpdateStaticResourceServiceEndpoint.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Commerce.Payments.PidlFactory.V7.PIDLFeatureProcess
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Web;
     using Microsoft.Commerce.Payments.PidlModel.V7;
-    using Microsoft.Commerce.Tracing;
 
     /**
      * This feature is used to update all the logo urls in pidl display hints to point to staticresources CDN

--- a/net8/private/Payments/Tests/CIT.PXService/app.config
+++ b/net8/private/Payments/Tests/CIT.PXService/app.config
@@ -55,14 +55,6 @@
         <bindingRedirect oldVersion="0.0.0.0-5.1.218.0" newVersion="5.1.218.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Bond.Attributes" publicKeyToken="87e9ead25a117286" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.100" newVersion="13.0.0.100" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Bond" publicKeyToken="87e9ead25a117286" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.100" newVersion="13.0.0.100" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Rest.ClientRuntime" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
@@ -137,10 +129,6 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VariantAssignment.Contract" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Bond.IO" publicKeyToken="87e9ead25a117286" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.100" newVersion="13.0.0.100" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/net8/private/Payments/Tests/CIT.PXService/packages.config
+++ b/net8/private/Payments/Tests/CIT.PXService/packages.config
@@ -2,16 +2,12 @@
 <packages>
   <package id="Azure.Analytics.Experimentation.VariantAssignment" version="5.8.2446104" targetFramework="net472" />
   <package id="Azure.Analytics.Experimentation.VariantAssignment.Contract" version="5.8.2446104" targetFramework="net472" />
-  <package id="Bond.Core.CSharp" version="13.0.0" targetFramework="net472" />
-  <package id="Bond.CSharp" version="13.0.0" targetFramework="net472" />
-  <package id="Bond.Runtime.CSharp" version="13.0.0" targetFramework="net472" />
   <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
   <package id="Microsoft.Asimov.Experimentation.ClientLibrary.dll" version="1.0.15" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.SelfHost" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net472" />
   <package id="Microsoft.Commerce.Payments.Management.CertificateVerificationCore" version="1.3.30" targetFramework="net472" />
-  <package id="Microsoft.CommonSchema.Bond" version="4.0.17341.1" targetFramework="net472" />
   <package id="Microsoft.CommonSchema.Services" version="5.1.218" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.4.1" targetFramework="net472" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net472" />
@@ -27,7 +23,6 @@
   <package id="Microsoft.Extensions.Options" version="7.0.0" targetFramework="net472" />
   <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="7.0.0" targetFramework="net472" />
   <package id="Microsoft.Extensions.Primitives" version="7.0.0" targetFramework="net472" />
-  <package id="Microsoft.VariantAssignment.Bond" version="4.1.227711" targetFramework="net472" />
   <package id="Moq" version="4.10.1" targetFramework="net45" />
   <package id="Ms.Qos" version="4.0.17341.1" targetFramework="net472" />
   <package id="Ms.Qos.IncomingServiceRequest" version="4.0.17341.1" targetFramework="net472" />

--- a/net8/private/Payments/Tests/Test.Common/ServiceClient.cs
+++ b/net8/private/Payments/Tests/Test.Common/ServiceClient.cs
@@ -5,7 +5,6 @@ namespace Test.Common
     using Microsoft.Commerce.Payments.Common.Tracing;
     using Microsoft.Commerce.Payments.Common.Transaction;
     using Microsoft.Commerce.Payments.Common.Web;
-    using Microsoft.Commerce.Tracing;
     using Newtonsoft.Json;
     using System;
     using System.Collections.Generic;


### PR DESCRIPTION
## Summary
- drop Bond package references from PXService and CIT test projects
- strip Bond assembly bindings and clean up PXCommon usage of tracing helpers
- align PXService code with updated Common project

## Testing
- `dotnet vstest "/UnitTests/CIT.PXService/CIT.PXService.dll" --TestCaseFilter:"FullyQualifiedName~AddressDescriptionsTests"` *(failed: The argument /UnitTests/CIT.PXService/CIT.PXService.dll is invalid)*


------
https://chatgpt.com/codex/tasks/task_e_68b98a82918c832997884a076142bb33