### PR TITLE
Ensure self-hosted PX service executes flight handler middleware

### DIFF
--- a/net8/private/Payments/Tests/SelfHostedPXServiceCore/SelfHostedPxService.cs
+++ b/net8/private/Payments/Tests/SelfHostedPXServiceCore/SelfHostedPxService.cs
@@ -86,6 +86,7 @@ namespace SelfHostedPXServiceCore
                 configureApp: app =>
                 {
                     app.UseMiddleware<PXServiceApiVersionHandler>();
+                    app.UseMiddleware<PXServiceFlightHandler>();
                     if (!WebHostingUtility.IsApplicationSelfHosted())
                     {
                       app.UseMiddleware<PXTraceCorrelationHandler>(


### PR DESCRIPTION
## Summary
- ensure PXServiceFlightHandler middleware executes in self-hosted PX service

## Testing
- `dotnet test CIT.PXService.csproj --filter FullyQualifiedName~AddressDescriptionsTests --logger "trx;LogFileName=address.trx"` *(fails: Assert.AreEqual, Assert.IsNotNull)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb7e8a6c8329a7b688b3261bf6a2